### PR TITLE
feat: toolchains category as SSOT for multi-version apt install + BOLT strip fix

### DIFF
--- a/src/hyperi_ci/cli.py
+++ b/src/hyperi_ci/cli.py
@@ -393,6 +393,14 @@ def install_native_deps(
             "--dry-run", "-n", help="Show what would be installed without installing"
         ),
     ] = False,
+    all_mode: Annotated[
+        bool,
+        typer.Option(
+            "--all",
+            help="Install every entry unconditionally (bypass manifest matching). "
+            "Use for runner image bake; stay default for CI-time conditional install.",
+        ),
+    ] = False,
 ) -> None:
     """Detect and install native system dependencies for a language."""
     from hyperi_ci.native_deps import install_native_deps as _install
@@ -400,10 +408,74 @@ def install_native_deps(
 
     dir_path = Path(project_dir) if project_dir else None
     if dry_run:
-        print_needed(language, project_dir=dir_path)
+        print_needed(language, project_dir=dir_path, all_mode=all_mode)
         return
-    rc = _install(language, project_dir=dir_path)
+    rc = _install(language, project_dir=dir_path, all_mode=all_mode)
     raise typer.Exit(rc)
+
+
+@app.command(name="install-toolchains")
+def install_toolchains(
+    family: Annotated[
+        str,
+        typer.Argument(
+            help="Toolchain family (llvm, gcc). Defaults to 'all' = every family.",
+        ),
+    ] = "all",
+    project_dir: Annotated[
+        str | None,
+        typer.Option("--project-dir", "-C", help="Project root directory"),
+    ] = None,
+    dry_run: Annotated[
+        bool,
+        typer.Option(
+            "--dry-run", "-n", help="Show what would be installed without installing"
+        ),
+    ] = False,
+    all_mode: Annotated[
+        bool,
+        typer.Option(
+            "--all",
+            help="Install every version unconditionally (bypass manifest matching). "
+            "Used for runner image bake. Default is conditional install.",
+        ),
+    ] = False,
+) -> None:
+    """Install multi-version toolchain families (LLVM, GCC).
+
+    By default fans out across every family in `config/toolchains/` and
+    matches project manifests to decide what to install. Pass `--all` on
+    a runner image bake to install every version of every family
+    regardless of manifest.
+
+    Examples:
+        hyperi-ci install-toolchains --all        # bake everything
+        hyperi-ci install-toolchains llvm --all   # bake only LLVM
+        hyperi-ci install-toolchains              # CI-time: conditional
+        hyperi-ci install-toolchains llvm         # CI-time: LLVM if triggered
+    """
+    from hyperi_ci.native_deps import _TOOLCHAINS_DIR, print_needed
+    from hyperi_ci.native_deps import install_native_deps as _install
+
+    dir_path = Path(project_dir) if project_dir else None
+
+    # `all` fans out to every toolchain YAML in config/toolchains/
+    if family == "all":
+        families = sorted(f.stem for f in _TOOLCHAINS_DIR.glob("*.yaml"))
+    else:
+        families = [family]
+
+    for fam in families:
+        if dry_run:
+            print_needed(
+                fam, project_dir=dir_path, category="toolchains", all_mode=all_mode
+            )
+            continue
+        rc = _install(
+            fam, project_dir=dir_path, category="toolchains", all_mode=all_mode
+        )
+        if rc != 0:
+            raise typer.Exit(rc)
 
 
 @app.command(name="install-deps")

--- a/src/hyperi_ci/config/toolchains/gcc.yaml
+++ b/src/hyperi_ci/config/toolchains/gcc.yaml
@@ -1,0 +1,36 @@
+# Project:   HyperI CI
+# File:      src/hyperi_ci/config/toolchains/gcc.yaml
+# Purpose:   Multi-version GCC toolchain install from distro repos
+#
+# GCC 13 and 14 both ship in current supported distros (Ubuntu noble,
+# Debian trixie, Ubuntu resolute) via their native repos — no PPA needed.
+# Parallel installs coexist at /usr/bin/gcc-{13,14} / g++-{13,14}.
+# The default `gcc` alternative is whatever the distro ships unchanged.
+
+- name: gcc-toolchain
+  versions: [13, 14]
+  patterns:
+    - "Cargo.toml"                   # Rust native-C build deps
+    - "[package]"
+    - "CMakeLists.txt"               # C/C++ projects
+    - "configure.ac"
+    - "setup.py"                     # Python C extension builds
+    - "pyproject.toml"
+    - "package.json"                 # node-gyp native addons
+    - "binding.gyp"
+  manifest_files:
+    - Cargo.toml
+    - CMakeLists.txt
+    - configure.ac
+    - setup.py
+    - pyproject.toml
+    - package.json
+    - binding.gyp
+    - .hyperi-ci.yaml
+  dpkg_check: gcc-{V}
+  # No custom apt_repos — distro repos ship gcc-13 and gcc-14 on every
+  # codename in our supported matrix (noble, trixie, resolute).
+  apt_packages:
+    - gcc-{V}
+    - g++-{V}
+    - libstdc++-{V}-dev

--- a/src/hyperi_ci/config/toolchains/llvm.yaml
+++ b/src/hyperi_ci/config/toolchains/llvm.yaml
@@ -1,0 +1,67 @@
+# Project:   HyperI CI
+# File:      src/hyperi_ci/config/toolchains/llvm.yaml
+# Purpose:   Multi-version LLVM/Clang toolchain install from apt.llvm.org
+#
+# Schema (shared with native-deps/, plus the `versions:` list):
+#   name:           Human-readable label (log line gets " v{V}" suffix per version)
+#   versions:       List of LLVM major versions. Each entry below is expanded
+#                   into N DepGroups with `{V}` substituted everywhere.
+#   patterns:       Manifest substrings that trigger install in conditional
+#                   mode. Ignored in `--all` mode (runner image bake).
+#   manifest_files: Files to search for patterns.
+#   dpkg_check:     dpkg package name — skips install if present.
+#   apt_repos:      APT repos to add before installing.
+#   apt_packages:   Packages to install.
+#
+# Per LLVM/Clang standards (C++ 22 stable, 21 for ClickHouse fork CI, 19
+# for ClickHouse OSS compatibility, 20 as intermediate). BOLT (post-link
+# optimiser) bundled per-version; ld.lld linker required for BOLT's
+# `--emit-relocs` flow.
+#
+# apt.llvm.org provides llvm-toolchain-{noble,trixie,resolute}-NN repos
+# for each version. The `${OS_CODENAME}` placeholder (used in apt_repos
+# below) is resolved at load time from the `$OS_CODENAME` env var or
+# `lsb_release -cs`.
+
+- name: llvm-toolchain
+  versions: [19, 20, 21, 22]
+  # Conditional triggers (ignored in --all): any C/C++/Rust/CMake project
+  patterns:
+    - "Cargo.toml"                   # Rust workspace marker
+    - "[package]"                    # Rust package marker (Cargo.toml)
+    - "CMakeLists.txt"               # CMake project
+    - "configure.ac"                 # Autotools project
+    - "c_std"                        # Meson C/C++ project
+    - "cpp_std"
+  manifest_files:
+    - Cargo.toml
+    - Cargo.lock
+    - CMakeLists.txt
+    - configure.ac
+    - meson.build
+    - .hyperi-ci.yaml
+  dpkg_check: clang-{V}
+  apt_repos:
+    - key_url: https://apt.llvm.org/llvm-snapshot.gpg.key
+      keyring: /usr/share/keyrings/llvm.gpg
+      # ${OS_CODENAME} is substituted at load time from lsb_release -cs,
+      # so the same YAML works on noble, trixie, and resolute. {V} is
+      # substituted per-version by the multi-version expander.
+      url: https://apt.llvm.org/${OS_CODENAME}/
+      codename: llvm-toolchain-${OS_CODENAME}-{V}
+  apt_packages:
+    - clang-{V}
+    - clang-tools-{V}
+    - clangd-{V}
+    - lld-{V}
+    - lldb-{V}
+    - llvm-{V}
+    - llvm-{V}-dev
+    - llvm-{V}-tools
+    - libclang-{V}-dev
+    - libclang-rt-{V}-dev
+    - libc++-{V}-dev
+    - libc++abi-{V}-dev
+    - libomp-{V}-dev
+    - libunwind-{V}-dev
+    - bolt-{V}

--- a/src/hyperi_ci/languages/rust/pgo.py
+++ b/src/hyperi_ci/languages/rust/pgo.py
@@ -347,27 +347,51 @@ def _instrumented_binary_path(
     return cwd / "target" / target / "release" / binary_name
 
 
-def _bolt_linker_env(target: str) -> dict[str, str]:
-    """Env overrides that force lld as the linker for the given target.
+def _bolt_build_env(target: str) -> dict[str, str]:
+    """Env overrides for cargo-pgo BOLT build and optimize steps.
 
-    BOLT's instrumented builds pass `-Wl,-q` (`--emit-relocs`) which mold
-    and GNU BFD don't handle reliably — mold segfaults on some link
-    combinations, BFD reports "invalid operation". LLD is the canonical
-    BOLT-compatible linker.
+    BOLT imposes two linker-level requirements that collide with common
+    release-profile settings:
 
-    This replaces the project's per-target `rustflags` during BOLT steps
-    only. Project-specific flags like `-C target-cpu=x86-64-v3` are lost
-    for the BOLT-instrumented build, which is acceptable because that
-    binary only runs the workload to collect BOLT profile data — branch
-    profile correctness is independent of codegen target-cpu.
+    1. **Linker must be lld.** BOLT's instrumented builds pass
+       `-Wl,-q` (`--emit-relocs`) which mold segfaults on and GNU BFD
+       rejects. lld is the canonical BOLT-compatible linker.
+
+    2. **strip must be disabled.** Rust's `[profile.release] strip = true`
+       appends `-Wl,--strip-all` to the link, which lld refuses to
+       combine with `--emit-relocs`. We override via
+       `CARGO_PROFILE_RELEASE_STRIP=none` for the BOLT steps only —
+       the project's regular release build keeps whatever strip
+       setting it declared. Final binary is stripped by hyperi-ci's
+       post-build packaging separately, so dropping cargo-level strip
+       here doesn't bloat the shipped artefact.
+
+    These overrides apply to both the instrumented build (used only
+    for profile collection) and the final BOLT-optimized build.
+
+    The per-target `rustflags` override replaces the project's own
+    target-specific flags during BOLT steps only — flags like
+    `-C target-cpu=x86-64-v3` are lost for the instrumented build,
+    which is acceptable because that binary only runs the workload to
+    collect profile data (branch profile correctness is independent of
+    codegen target-cpu).
     """
     # Cargo env var for target-specific rustflags uses UPPERCASE with
     # hyphens and dots replaced by underscores (e.g. x86_64-unknown-linux-gnu
     # → X86_64_UNKNOWN_LINUX_GNU).
-    env_key = (
+    target_rustflags_key = (
         f"CARGO_TARGET_{target.upper().replace('-', '_').replace('.', '_')}_RUSTFLAGS"
     )
-    return {env_key: "-C link-arg=-fuse-ld=lld"}
+    return {
+        target_rustflags_key: "-C link-arg=-fuse-ld=lld",
+        "CARGO_PROFILE_RELEASE_STRIP": "none",
+    }
+
+
+# Backwards-compat alias for external callers / pre-1.11 tests.
+# No in-tree caller uses this — _run_bolt calls _bolt_build_env directly.
+# Remove in v2.
+_bolt_linker_env = _bolt_build_env
 
 
 def _run_bolt(
@@ -383,9 +407,9 @@ def _run_bolt(
     (covered by the `bolt-NN` + `lld-NN` apt packages from apt.llvm.org).
     Silent skip if any toolchain binary is missing.
 
-    Forces lld as the linker for both `cargo pgo bolt build` and
-    `cargo pgo bolt optimize` — mold and BFD don't handle the
-    `--emit-relocs` metadata BOLT requires. See `_bolt_linker_env()`.
+    Forces lld as the linker and disables strip for both
+    `cargo pgo bolt build` and `cargo pgo bolt optimize` — see
+    `_bolt_build_env()` for rationale.
 
     Requires the PGO step to have run already (BOLT uses the PGO profile).
     """
@@ -395,10 +419,10 @@ def _run_bolt(
         )
         return 0  # Non-fatal
 
-    # Merge project env_overrides (LTO etc.) with the BOLT-step linker
-    # override. Linker env takes precedence over project config for the
-    # target-specific rustflags — this is intentional.
-    bolt_env = {**(extra_env or {}), **_bolt_linker_env(target)}
+    # Merge project env_overrides (LTO etc.) with the BOLT-step build
+    # env (fuse-ld=lld + strip=none). BOLT env takes precedence over
+    # project config for the target-specific rustflags — intentional.
+    bolt_env = {**(extra_env or {}), **_bolt_build_env(target)}
 
     # BOLT instrument build
     info(f"BOLT: building instrumented binary for {target} (linker forced to lld)")

--- a/src/hyperi_ci/native_deps.py
+++ b/src/hyperi_ci/native_deps.py
@@ -24,10 +24,29 @@ from pathlib import Path
 import yaml
 from hyperi_pylib import logger
 
-# Ubuntu LTS codenames in reverse chronological order for fallback
-_LTS_CODENAMES = ["noble", "jammy", "focal"]
+# Codenames to try as fallbacks when a given APT repo doesn't ship
+# packages for the current OS codename. Ordered by preference (newest
+# Ubuntu LTS first, then older LTS, then Debian stable). Resolute
+# (Ubuntu 26.04 LTS, April 2026) is the current latest; trixie (Debian
+# 13) is supported alongside for ESH projects.
+_FALLBACK_CODENAMES = ["resolute", "noble", "jammy", "focal", "trixie"]
 
-_NATIVE_DEPS_DIR = Path(__file__).resolve().parent / "config" / "native-deps"
+_CONFIG_ROOT = Path(__file__).resolve().parent / "config"
+_NATIVE_DEPS_DIR = _CONFIG_ROOT / "native-deps"
+_TOOLCHAINS_DIR = _CONFIG_ROOT / "toolchains"
+
+# Supported categories map to config subdirectories. Both share the same
+# YAML schema (patterns, manifest_files, dpkg_check, apt_repos, apt_packages)
+# plus the optional `versions:` list for multi-version expansion.
+#
+# Semantic difference:
+#   native-deps: conditional by default (install only if manifest matches)
+#   toolchains:  conditional in --auto mode; --all bypasses pattern check.
+#                Covers multi-version apt families (LLVM 19-22, GCC 13/14).
+_CATEGORY_DIRS: dict[str, Path] = {
+    "native-deps": _NATIVE_DEPS_DIR,
+    "toolchains": _TOOLCHAINS_DIR,
+}
 
 
 @dataclass
@@ -62,7 +81,7 @@ _DEFAULT_LLVM_VERSION = "22"
 
 
 def _expand_template_vars(text: str) -> str:
-    """Expand ${VAR} placeholders in native-deps YAML.
+    """Expand ${VAR} placeholders in YAML configs.
 
     Supports a small set of hyperi-ci-controlled variables — keeps the
     YAML readable while letting ops override per environment without
@@ -70,47 +89,107 @@ def _expand_template_vars(text: str) -> str:
 
     Recognised variables:
       HYPERCI_LLVM_VERSION  — LLVM/BOLT major version (default: 22)
+      OS_CODENAME           — current OS codename from lsb_release -cs
+                              (e.g. noble, trixie, resolute). Lets a single
+                              YAML reference distro-specific apt.llvm.org
+                              subpaths (https://apt.llvm.org/${OS_CODENAME}/).
 
     Unknown ${VAR} placeholders pass through unchanged so apt-cache
     surfaces a clear "package not found" error instead of a silent
     mis-resolve.
     """
     llvm_version = os.environ.get("HYPERCI_LLVM_VERSION", _DEFAULT_LLVM_VERSION)
-    return text.replace("${HYPERCI_LLVM_VERSION}", llvm_version)
+    os_codename = os.environ.get("OS_CODENAME") or _get_os_codename() or "noble"
+    return text.replace("${HYPERCI_LLVM_VERSION}", llvm_version).replace(
+        "${OS_CODENAME}", os_codename
+    )
 
 
-def _load_dep_groups(language: str) -> list[DepGroup]:
-    """Load dep group definitions for a language from bundled config."""
-    config_file = _NATIVE_DEPS_DIR / f"{language}.yaml"
+def _substitute_version(text: str, version: str) -> str:
+    """Substitute the {V} placeholder with a concrete version."""
+    return text.replace("{V}", version)
+
+
+def _dep_group_from_entry(entry: dict, version: str | None = None) -> DepGroup:
+    """Materialise one DepGroup from a YAML entry, optionally substituting {V}.
+
+    When `version` is None (the common native-deps path) the entry is used
+    verbatim. When `version` is a concrete string (the toolchains path)
+    `{V}` is substituted everywhere it appears: `dpkg_check`, every
+    `apt_repos[*].codename`, every `apt_packages[*]`, and the `name`
+    (so log lines distinguish versions).
+    """
+
+    def sub(text: str) -> str:
+        return _substitute_version(text, version) if version is not None else text
+
+    name = sub(entry["name"])
+    if version is not None:
+        # Disambiguate the group name so log lines are readable
+        name = f"{entry['name']} v{version}"
+
+    return DepGroup(
+        name=name,
+        # patterns and manifest_files stay shared across version expansions
+        patterns=entry.get("patterns", []),
+        manifest_files=entry.get("manifest_files", []),
+        dpkg_check=sub(entry["dpkg_check"]),
+        apt_packages=[sub(p) for p in entry.get("apt_packages", [])],
+        apt_repos=[
+            AptRepo(
+                key_url=r["key_url"],
+                keyring=r["keyring"],
+                url=r["url"],
+                codename=sub(r.get("codename", "auto")),
+                components=r.get("components", "main"),
+            )
+            for r in entry.get("apt_repos", [])
+        ],
+        dpkg_min_version=entry.get("dpkg_min_version", ""),
+    )
+
+
+def _load_dep_groups(language: str, category: str = "native-deps") -> list[DepGroup]:
+    """Load dep group definitions from bundled config.
+
+    Entries with a `versions:` list expand into one DepGroup per version,
+    with `{V}` substituted in `dpkg_check`, `apt_repos[*].codename`, and
+    every `apt_packages[*]`. Entries without `versions:` are loaded as-is
+    (backward-compatible with existing native-deps YAMLs).
+    """
+    config_dir = _CATEGORY_DIRS.get(category)
+    if config_dir is None:
+        logger.warning(f"Unknown config category: {category}")
+        return []
+
+    config_file = config_dir / f"{language}.yaml"
     if not config_file.exists():
-        logger.warning(f"No native-deps config for language: {language}")
+        logger.warning(f"No {category} config for: {language}")
         return []
 
     raw = yaml.safe_load(_expand_template_vars(config_file.read_text()))
     if not raw:
         return []
 
-    return [
-        DepGroup(
-            name=entry["name"],
-            patterns=entry["patterns"],
-            manifest_files=entry["manifest_files"],
-            dpkg_check=entry["dpkg_check"],
-            apt_packages=entry.get("apt_packages", []),
-            apt_repos=[
-                AptRepo(
-                    key_url=r["key_url"],
-                    keyring=r["keyring"],
-                    url=r["url"],
-                    codename=r.get("codename", "auto"),
-                    components=r.get("components", "main"),
-                )
-                for r in entry.get("apt_repos", [])
-            ],
-            dpkg_min_version=entry.get("dpkg_min_version", ""),
-        )
-        for entry in raw
-    ]
+    groups: list[DepGroup] = []
+    for entry in raw:
+        versions = entry.get("versions")
+        if versions is None:
+            # No versions key — load as-is (backward-compatible native-deps path)
+            groups.append(_dep_group_from_entry(entry))
+        elif not versions:
+            # Empty list is almost certainly a config bug — {V} would leak
+            # into the final install command and fail at apt-cache time
+            # with a confusing "package not found" message. Warn loudly.
+            logger.warning(
+                f"entry {entry.get('name', '<unnamed>')!r} in "
+                f"{config_file} has empty `versions:` — skipping"
+            )
+        else:
+            # Multi-version expansion: one DepGroup per version
+            for v in versions:
+                groups.append(_dep_group_from_entry(entry, version=str(v)))
+    return groups
 
 
 def _read_manifests(project_dir: Path, manifest_files: list[str]) -> str:
@@ -163,7 +242,7 @@ def _resolve_codename(repo: AptRepo) -> str:
         logger.info(f"Repo {repo.url} supports current codename: {os_codename}")
         return os_codename
 
-    for lts in _LTS_CODENAMES:
+    for lts in _FALLBACK_CODENAMES:
         if lts == os_codename:
             continue
         if _repo_has_codename(repo.url, lts):
@@ -174,7 +253,7 @@ def _resolve_codename(repo: AptRepo) -> str:
             return lts
 
     logger.warning(f"No supported codename found for {repo.url}")
-    return os_codename or _LTS_CODENAMES[0]
+    return os_codename or _FALLBACK_CODENAMES[0]
 
 
 def _get_dpkg_arch() -> str:
@@ -344,12 +423,22 @@ def _apt_install(packages: list[str]) -> int:
     return install.returncode
 
 
-def install_native_deps(language: str, project_dir: Path | None = None) -> int:
-    """Detect and install native system deps for the given language.
+def install_native_deps(
+    language: str,
+    project_dir: Path | None = None,
+    category: str = "native-deps",
+    all_mode: bool = False,
+) -> int:
+    """Detect and install deps for the given language.
 
     Args:
-        language: Language identifier (rust, typescript, golang, python).
+        language: Language identifier (rust, typescript, golang, python) for
+            `native-deps`, or toolchain family (llvm, gcc) for `toolchains`.
         project_dir: Project root. Defaults to cwd.
+        category: Config subdirectory — `native-deps` or `toolchains`.
+        all_mode: If True, bypass the manifest-pattern check and install every
+            group unconditionally. Used by runner-image bake (`--all`); CI-time
+            invocations on vanilla runners stay conditional (default).
 
     Returns:
         0 on success, non-zero on failure.
@@ -357,29 +446,32 @@ def install_native_deps(language: str, project_dir: Path | None = None) -> int:
     cwd = project_dir or Path.cwd()
 
     if platform.system() != "Linux":
-        logger.info(f"Skipping native deps on {platform.system()}")
+        logger.info(f"Skipping {category} on {platform.system()}")
         return 0
 
-    dep_groups = _load_dep_groups(language)
+    dep_groups = _load_dep_groups(language, category=category)
     if not dep_groups:
-        logger.info(f"No native dep groups defined for {language}")
+        logger.info(f"No {category} groups defined for {language}")
         return 0
 
     needed: list[DepGroup] = []
     for group in dep_groups:
-        content = _read_manifests(cwd, group.manifest_files)
-        if not content:
-            continue
+        if not all_mode:
+            # Conditional mode: only install if a manifest pattern matches
+            content = _read_manifests(cwd, group.manifest_files)
+            if not content:
+                continue
+            if not _patterns_match(content, group.patterns):
+                continue
 
-        if _patterns_match(content, group.patterns):
-            if _is_dpkg_installed(group.dpkg_check, group.dpkg_min_version):
-                logger.info(f"[{group.name}] already installed ({group.dpkg_check})")
-            else:
-                logger.info(f"[{group.name}] needs install: {group.apt_packages}")
-                needed.append(group)
+        if _is_dpkg_installed(group.dpkg_check, group.dpkg_min_version):
+            logger.info(f"[{group.name}] already installed ({group.dpkg_check})")
+        else:
+            logger.info(f"[{group.name}] needs install: {group.apt_packages}")
+            needed.append(group)
 
     if not needed:
-        logger.info(f"All native deps satisfied for {language}")
+        logger.info(f"All {category} satisfied for {language}")
         return 0
 
     # Add any custom APT repos before installing
@@ -399,18 +491,20 @@ def install_native_deps(language: str, project_dir: Path | None = None) -> int:
                 all_packages.append(pkg)
                 seen.add(pkg)
 
-    logger.info(f"Installing native packages: {all_packages}")
+    logger.info(f"Installing {category} packages: {all_packages}")
     rc = _apt_install(all_packages)
     if rc != 0:
         logger.error(f"apt-get install failed (exit {rc})")
         return rc
 
-    # Universal per-language tooling (cargo / npm / pip / go-install)
-    rc = _install_language_tools(language)
-    if rc != 0:
-        return rc
+    # Universal per-language tooling (cargo / npm / pip / go-install) only
+    # applies to the native-deps category — toolchains have no language tools.
+    if category == "native-deps":
+        rc = _install_language_tools(language)
+        if rc != 0:
+            return rc
 
-    logger.info(f"Native deps installed for {language}")
+    logger.info(f"{category} installed for {language}")
     return 0
 
 
@@ -510,24 +604,32 @@ def _install_language_tools(language: str) -> int:
     return 0
 
 
-def print_needed(language: str, project_dir: Path | None = None) -> None:
+def print_needed(
+    language: str,
+    project_dir: Path | None = None,
+    category: str = "native-deps",
+    all_mode: bool = False,
+) -> None:
     """Print which dep groups would be triggered (dry-run helper)."""
     cwd = project_dir or Path.cwd()
-    dep_groups = _load_dep_groups(language)
+    dep_groups = _load_dep_groups(language, category=category)
 
     for group in dep_groups:
-        content = _read_manifests(cwd, group.manifest_files)
-        matched = content and _patterns_match(content, group.patterns)
+        if all_mode:
+            matched = True
+        else:
+            content = _read_manifests(cwd, group.manifest_files)
+            matched = bool(content) and _patterns_match(content, group.patterns)
         installed = (
             _is_dpkg_installed(group.dpkg_check)
             if platform.system() == "Linux"
             else None
         )
         status = (
-            "matched+installed"
+            "would-install (already present)"
             if matched and installed
-            else "matched+needed"
+            else "would-install"
             if matched and not installed
-            else "not matched"
+            else "skip (no match)"
         )
         print(f"  {group.name}: {status}", file=sys.stderr)

--- a/src/hyperi_ci/native_deps.py
+++ b/src/hyperi_ci/native_deps.py
@@ -208,12 +208,21 @@ def _patterns_match(content: str, patterns: list[str]) -> bool:
 
 
 def _get_os_codename() -> str:
-    """Get the current OS codename via lsb_release."""
-    result = subprocess.run(
-        ["lsb_release", "-cs"],
-        capture_output=True,
-        text=True,
-    )
+    """Get the current OS codename via lsb_release, or "" if unavailable.
+
+    macOS has no `lsb_release` binary — `FileNotFoundError` propagates up
+    from Popen. Swallow it so callers get an empty string (same contract
+    as a non-zero exit on Linux); the `_expand_template_vars` fallback
+    then defaults `${OS_CODENAME}` to "noble".
+    """
+    try:
+        result = subprocess.run(
+            ["lsb_release", "-cs"],
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError:
+        return ""
     return result.stdout.strip() if result.returncode == 0 else ""
 
 

--- a/tests/unit/test_native_deps.py
+++ b/tests/unit/test_native_deps.py
@@ -400,6 +400,17 @@ class TestExpandTemplateVarsOsCodename:
         with patch.object(native_deps, "_get_os_codename", return_value=""):
             assert _expand_template_vars("${OS_CODENAME}") == "noble"
 
+    def test_get_os_codename_tolerates_missing_lsb_release(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """macOS CI runners have no lsb_release — must return "" not raise."""
+
+        def _raise_not_found(*_args, **_kwargs):
+            raise FileNotFoundError(2, "No such file", "lsb_release")
+
+        monkeypatch.setattr(native_deps.subprocess, "run", _raise_not_found)
+        assert native_deps._get_os_codename() == ""
+
 
 class TestAllModeBypass:
     """`all_mode=True` bypasses pattern matching for runner image bake."""

--- a/tests/unit/test_native_deps.py
+++ b/tests/unit/test_native_deps.py
@@ -286,3 +286,184 @@ class TestDepGroupLoading:
         assert bolt.dpkg_check == "bolt-19"
         assert "bolt-19" in bolt.apt_packages
         assert bolt.apt_repos[0].codename == "llvm-toolchain-noble-19"
+
+
+class TestMultiVersionToolchains:
+    """Toolchains category expands `versions:` list into N DepGroups.
+
+    One YAML entry with `versions: [19, 20, 21, 22]` becomes four DepGroups
+    with `{V}` substituted in `dpkg_check`, `apt_repos[*].codename`, and
+    every `apt_packages[*]`. The `name` is suffixed " vN" so log lines
+    distinguish versions.
+    """
+
+    def test_llvm_yaml_expands_to_one_group_per_version(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("OS_CODENAME", "noble")
+        groups = _load_dep_groups("llvm", category="toolchains")
+        # LLVM YAML declares versions [19, 20, 21, 22] → 4 groups
+        assert len(groups) == 4
+        names = [g.name for g in groups]
+        assert names == [
+            "llvm-toolchain v19",
+            "llvm-toolchain v20",
+            "llvm-toolchain v21",
+            "llvm-toolchain v22",
+        ]
+
+    def test_substitutes_version_in_dpkg_check_and_packages(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("OS_CODENAME", "noble")
+        groups = _load_dep_groups("llvm", category="toolchains")
+        v22 = next(g for g in groups if g.name.endswith("v22"))
+        assert v22.dpkg_check == "clang-22"
+        assert "clang-22" in v22.apt_packages
+        assert "bolt-22" in v22.apt_packages
+        assert "libclang-rt-22-dev" in v22.apt_packages
+        # {V} must not leak into the final packages
+        assert not any("{V}" in p for p in v22.apt_packages)
+
+    def test_substitutes_os_codename_and_version_in_repo(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Repo URL takes OS codename; repo codename takes both OS + version."""
+        monkeypatch.setenv("OS_CODENAME", "resolute")
+        groups = _load_dep_groups("llvm", category="toolchains")
+        v21 = next(g for g in groups if g.name.endswith("v21"))
+        assert v21.apt_repos[0].url == "https://apt.llvm.org/resolute/"
+        assert v21.apt_repos[0].codename == "llvm-toolchain-resolute-21"
+
+    def test_gcc_expansion_no_repos(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """GCC uses distro repos — empty apt_repos after expansion."""
+        monkeypatch.setenv("OS_CODENAME", "trixie")
+        groups = _load_dep_groups("gcc", category="toolchains")
+        assert len(groups) == 2
+        for g in groups:
+            assert g.apt_repos == []
+
+    def test_unknown_category_returns_empty(self) -> None:
+        assert _load_dep_groups("llvm", category="bogus") == []
+
+    def test_empty_versions_list_is_skipped_with_warning(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """An empty `versions: []` is a config bug — warn and skip."""
+        # Redirect the toolchains dir to a tmp location we control
+        bogus_dir = tmp_path / "toolchains"
+        bogus_dir.mkdir()
+        (bogus_dir / "broken.yaml").write_text(
+            "- name: broken-entry\n"
+            "  versions: []\n"
+            "  patterns: []\n"
+            "  manifest_files: []\n"
+            "  dpkg_check: 'clang-{V}'\n"
+            "  apt_packages:\n"
+            "    - 'clang-{V}'\n"
+        )
+        monkeypatch.setitem(native_deps._CATEGORY_DIRS, "toolchains", bogus_dir)
+        # Loguru bypasses stdlib logging / capsys — capture via .warning patch
+        warnings: list[str] = []
+        monkeypatch.setattr(
+            native_deps.logger, "warning", lambda msg: warnings.append(msg)
+        )
+        groups = _load_dep_groups("broken", category="toolchains")
+        assert groups == []
+        assert len(warnings) == 1
+        assert "empty `versions:`" in warnings[0]
+        assert "broken-entry" in warnings[0]
+
+
+class TestExpandTemplateVarsOsCodename:
+    """`${OS_CODENAME}` expansion resolves from env var or lsb_release."""
+
+    def test_env_override_wins_over_lsb_release(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("OS_CODENAME", "resolute")
+        assert _expand_template_vars("url: ${OS_CODENAME}/") == "url: resolute/"
+
+    def test_env_empty_falls_back_to_lsb_release(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("OS_CODENAME", raising=False)
+        with patch.object(native_deps, "_get_os_codename", return_value="noble"):
+            assert _expand_template_vars("${OS_CODENAME}") == "noble"
+
+    def test_lsb_release_missing_falls_back_to_noble(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("OS_CODENAME", raising=False)
+        with patch.object(native_deps, "_get_os_codename", return_value=""):
+            assert _expand_template_vars("${OS_CODENAME}") == "noble"
+
+
+class TestAllModeBypass:
+    """`all_mode=True` bypasses pattern matching for runner image bake."""
+
+    def test_all_mode_ignores_patterns(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        """A group whose patterns don't match should still install in --all mode."""
+        monkeypatch.setenv("OS_CODENAME", "noble")
+        # Stub platform.system to "Linux" so install logic runs
+        monkeypatch.setattr(native_deps.platform, "system", lambda: "Linux")
+        # Record which groups reach the install step
+        installed_packages: list[str] = []
+
+        def fake_apt_install(packages: list[str]) -> int:
+            installed_packages.extend(packages)
+            return 0
+
+        monkeypatch.setattr(native_deps, "_apt_install", fake_apt_install)
+        monkeypatch.setattr(
+            native_deps, "_is_dpkg_installed", lambda pkg, min_v="": False
+        )
+        monkeypatch.setattr(native_deps, "_add_apt_repo", lambda repo: 0)
+
+        # Empty project dir → no manifests → patterns would normally match nothing
+        rc = native_deps.install_native_deps(
+            "gcc",
+            project_dir=tmp_path,
+            category="toolchains",
+            all_mode=True,
+        )
+        assert rc == 0
+        # All GCC versions should have been queued regardless of patterns
+        assert "gcc-13" in installed_packages
+        assert "gcc-14" in installed_packages
+
+    def test_conditional_mode_skips_when_no_manifest_match(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        """Default (conditional) mode must skip when manifest patterns miss."""
+        monkeypatch.setenv("OS_CODENAME", "noble")
+        monkeypatch.setattr(native_deps.platform, "system", lambda: "Linux")
+        installed_packages: list[str] = []
+
+        def fake_apt_install(packages: list[str]) -> int:
+            installed_packages.extend(packages)
+            return 0
+
+        monkeypatch.setattr(native_deps, "_apt_install", fake_apt_install)
+        monkeypatch.setattr(
+            native_deps, "_is_dpkg_installed", lambda pkg, min_v="": False
+        )
+        monkeypatch.setattr(native_deps, "_add_apt_repo", lambda repo: 0)
+
+        # Empty project dir → no patterns match → nothing installed
+        rc = native_deps.install_native_deps(
+            "gcc",
+            project_dir=tmp_path,
+            category="toolchains",
+            all_mode=False,
+        )
+        assert rc == 0
+        assert installed_packages == []

--- a/tests/unit/test_rust_pgo.py
+++ b/tests/unit/test_rust_pgo.py
@@ -206,37 +206,53 @@ class TestBoltAvailabilityCheck:
             assert shim.resolve() == expected.resolve()
 
 
-class TestBoltLinkerOverride:
-    """BOLT steps force lld as the linker via CARGO_TARGET_<TRIPLE>_RUSTFLAGS.
+class TestBoltBuildEnv:
+    """BOLT steps need TWO env overrides to get a clean linker pass:
 
-    mold (on some projects) and GNU BFD can't handle the `--emit-relocs`
-    metadata cargo-pgo's BOLT flow requires. LLD is the canonical
-    BOLT-compatible linker. Verifies the env key construction for
-    common triples and that the rustflags value forces fuse-ld=lld.
+    1. `CARGO_TARGET_<TRIPLE>_RUSTFLAGS` with `-C link-arg=-fuse-ld=lld` —
+       mold segfaults on `--emit-relocs`, GNU BFD rejects it, lld is the
+       canonical BOLT-compatible linker.
+    2. `CARGO_PROFILE_RELEASE_STRIP=none` — lld refuses to combine
+       `--strip-all` with `--emit-relocs`, so projects with
+       `[profile.release] strip = true` otherwise fail the BOLT build.
+       Final binary is stripped by hyperi-ci's post-build packaging.
     """
 
-    def test_amd64_linux_triple_produces_correct_env_key(self) -> None:
-        from hyperi_ci.languages.rust.pgo import _bolt_linker_env
+    def test_amd64_linux_forces_lld_via_target_rustflags(self) -> None:
+        from hyperi_ci.languages.rust.pgo import _bolt_build_env
 
-        env = _bolt_linker_env("x86_64-unknown-linux-gnu")
-        assert "CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS" in env
+        env = _bolt_build_env("x86_64-unknown-linux-gnu")
         assert env["CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS"] == (
             "-C link-arg=-fuse-ld=lld"
         )
 
-    def test_arm64_linux_triple_produces_correct_env_key(self) -> None:
-        from hyperi_ci.languages.rust.pgo import _bolt_linker_env
+    def test_disables_strip_for_bolt_steps(self) -> None:
+        """strip=true + --emit-relocs is rejected by lld — override to none."""
+        from hyperi_ci.languages.rust.pgo import _bolt_build_env
 
-        env = _bolt_linker_env("aarch64-unknown-linux-gnu")
+        env = _bolt_build_env("x86_64-unknown-linux-gnu")
+        assert env["CARGO_PROFILE_RELEASE_STRIP"] == "none"
+
+    def test_arm64_linux_triple_produces_correct_env_key(self) -> None:
+        from hyperi_ci.languages.rust.pgo import _bolt_build_env
+
+        env = _bolt_build_env("aarch64-unknown-linux-gnu")
         assert "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_RUSTFLAGS" in env
+        assert env["CARGO_PROFILE_RELEASE_STRIP"] == "none"
 
     def test_triple_with_dots_is_sanitised_to_underscores(self) -> None:
         """Some triples have dots (e.g. Apple targets) — must become underscores."""
-        from hyperi_ci.languages.rust.pgo import _bolt_linker_env
+        from hyperi_ci.languages.rust.pgo import _bolt_build_env
 
         # Cargo's env var convention replaces BOTH - and . with _
-        env = _bolt_linker_env("aarch64-apple-darwin")
+        env = _bolt_build_env("aarch64-apple-darwin")
         assert "CARGO_TARGET_AARCH64_APPLE_DARWIN_RUSTFLAGS" in env
+
+    def test_legacy_alias_still_works(self) -> None:
+        """_bolt_linker_env is kept as backwards-compat alias for one release."""
+        from hyperi_ci.languages.rust.pgo import _bolt_build_env, _bolt_linker_env
+
+        assert _bolt_linker_env is _bolt_build_env
 
 
 class TestWorkloadExecution:


### PR DESCRIPTION
## Summary

Phase 1 of migrating runner-image dep installation into hyperi-ci as Single Source of Truth.

- **`toolchains` category** alongside existing `native-deps` — shared YAML schema, different default semantics (toolchains target runner-image bake; native-deps stay conditional).
- **`versions: [...]` expansion** — one YAML entry expands into N DepGroups with `{V}` substituted in `dpkg_check`, `apt_repos[*].codename`, and every `apt_packages[*]`.
- **`${OS_CODENAME}`** template var — one YAML works across noble, trixie, resolute.
- **`--all` mode** — bypass manifest pattern check for unconditional install (runner image bake). Default stays conditional for CI-time installs on vanilla GH runners.
- **`hyperi-ci install-toolchains`** CLI — `family` defaults to `all` so `install-toolchains --all` bakes every family.
- **BOLT fix**: `CARGO_PROFILE_RELEASE_STRIP=none` during BOLT steps — lld refuses `--strip-all` with `--emit-relocs`. Rename `_bolt_linker_env` → `_bolt_build_env` (alias kept for one release).
- **Resolute (Ubuntu 26.04 LTS, April 2026)** added to the codename fallback list. `_LTS_CODENAMES` → `_FALLBACK_CODENAMES` (the list also contains Debian trixie, so the old name was misleading).

Downstream consumer: hyperi-infra runner Dockerfiles switch from a bash install script to `RUN pip install 'hyperi-ci>=1.11' && hyperi-ci install-toolchains --all` — will land after this release ships to PyPI.

## Known follow-ups (in hyperi-infra TODO)

- CI-tools, base-apt, runtimes, cross-sysroot categories (phases 2-5). Each phase shrinks the runner Dockerfile further; pattern is established here.
- Runner-image `install-native-deps rust` and `install-toolchains llvm` have overlap on `bolt-22` / `lld-22`. Idempotent, not a blocker. Dedupe happens within a single call; across calls it just means apt sees the packages already installed.

## Test plan

- [x] `pytest tests/` — 431 passed, 7 deselected (added 11 new tests across TestMultiVersionToolchains, TestExpandTemplateVarsOsCodename, TestAllModeBypass, TestBoltBuildEnv)
- [x] `ruff check` + `ruff format` clean
- [x] `hyperi-ci check --quick` green
- [x] Manual smoke: load `llvm.yaml` → 4 DepGroups with correct `{V}` / `${OS_CODENAME}` substitution
- [x] Code review (superpowers:code-reviewer) — Critical: 0, Important: 3 fixed, Minor: noted

## Reviewer notes

- `_bolt_linker_env` kept as backwards-compat alias; no in-tree caller uses it. Removal tracked for v2.
- Empty `versions: []` is treated as a config bug (warns + skips the entry). Avoids `{V}` leaking into apt commands.
- Existing `native-deps/*.yaml` files (rust, python, golang, typescript) unchanged — backward-compat verified by existing test suite.