### PR TITLE
fix(native_deps): append apt sources instead of overwriting (v1.11.0 multi-version bake regression)

### DIFF
--- a/src/hyperi_ci/native_deps.py
+++ b/src/hyperi_ci/native_deps.py
@@ -318,11 +318,18 @@ def _add_apt_repo(repo: AptRepo) -> int:
     Idempotent on three levels:
       1. GPG keyring: skips download if keyring file already present.
       2. Exact sources.list match: skips write if our file already has
-         the exact same line.
+         the exact same line. Other unrelated lines in the file are
+         preserved (append, don't overwrite).
       3. Cross-file duplicate detection: skips write if ANY other apt
          source file already references the same url + codename — this
          handles self-hosted runners where admins have pre-configured
          upstream repos under a different filename.
+
+    Multi-version note: many entries can share a keyring (e.g. LLVM 19/20/
+    21/22 all use `/usr/share/keyrings/llvm.gpg`). The sources filename is
+    derived from the keyring stem, so multiple AptRepo writes collide on
+    one file. We APPEND — multiple `deb` lines in the same .list pointing
+    at the same keyring is valid apt syntax.
     """
     keyring_path = Path(repo.keyring)
     if keyring_path.exists():
@@ -374,14 +381,20 @@ def _add_apt_repo(repo: AptRepo) -> int:
     sources_name = keyring_path.stem + ".list"
     sources_path = Path("/etc/apt/sources.list.d") / sources_name
 
-    if sources_path.exists() and sources_path.read_text().strip() == sources_line:
+    # Skip if the exact `deb` line is already present in the file. Substring
+    # check (not equality) — the file may contain other entries for different
+    # versions of the same toolchain (e.g. llvm.list holds v19/v20/v21/v22).
+    if sources_path.exists() and sources_line in sources_path.read_text():
         logger.info(f"APT source already configured: {sources_path}")
         return 0
 
     logger.info(f"Adding APT source: {sources_line}")
+    # Append (don't overwrite) — `tee -a` creates the file if missing.
+    # Prepend a newline so subsequent lines don't get concatenated.
+    prefix = "" if not sources_path.exists() else "\n"
     result = subprocess.run(
-        ["sudo", "tee", str(sources_path)],
-        input=sources_line.encode(),
+        ["sudo", "tee", "-a", str(sources_path)],
+        input=f"{prefix}{sources_line}\n".encode(),
         capture_output=True,
     )
     return result.returncode

--- a/tests/unit/test_native_deps.py
+++ b/tests/unit/test_native_deps.py
@@ -7,6 +7,7 @@
 
 from __future__ import annotations
 
+import subprocess
 from pathlib import Path
 from unittest.mock import patch
 
@@ -260,6 +261,98 @@ class TestAddAptRepoIdempotency:
         assert "sudo" not in invoked, f"unexpected sudo (tee) call: {invoked}"
         # Our own filename (derived from keyring stem "llvm" + ".list") NOT created
         assert not (sources_dir / "llvm.list").exists()
+
+    def test_multi_version_writes_append_not_overwrite(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Multiple _add_apt_repo calls sharing a keyring must accumulate.
+
+        Multi-version toolchains (LLVM 19/20/21/22) reuse one keyring file,
+        which derives one sources filename. Before v1.11.1 the writer used
+        `tee` (overwrite), so only the last version's `deb` line survived.
+        Regression check: after four calls the file contains four lines.
+        """
+        fake_keyring = tmp_path / "llvm.gpg"
+        fake_keyring.write_bytes(b"fake-key")
+        sources_list, sources_dir = _seed_apt_tree(tmp_path, {})
+        _patch_apt_paths(monkeypatch, sources_list, sources_dir)
+
+        target_file = sources_dir / "llvm.list"
+
+        def fake_sudo_run(cmd, **kwargs):
+            # dpkg arch probe — return amd64
+            if cmd[:2] == ["dpkg", "--print-architecture"]:
+                return subprocess.CompletedProcess(cmd, 0, stdout="amd64\n", stderr="")
+            # Simulate sudo tee -a: append stdin to the target file
+            if cmd[:3] == ["sudo", "tee", "-a"]:
+                path = Path(cmd[3])
+                mode = "ab" if path.exists() else "wb"
+                with open(path, mode) as f:
+                    f.write(kwargs.get("input", b""))
+                return subprocess.CompletedProcess(cmd, 0, stdout=b"", stderr=b"")
+            # Legacy `sudo tee` (no -a) would land here; kept for regression detection.
+            if cmd[:2] == ["sudo", "tee"]:
+                path = Path(cmd[2])
+                with open(path, "wb") as f:
+                    f.write(kwargs.get("input", b""))
+                return subprocess.CompletedProcess(cmd, 0, stdout=b"", stderr=b"")
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+        monkeypatch.setattr(native_deps.subprocess, "run", fake_sudo_run)
+
+        for version in ("19", "20", "21", "22"):
+            repo = AptRepo(
+                key_url="https://apt.llvm.org/llvm-snapshot.gpg.key",
+                keyring=str(fake_keyring),
+                url="https://apt.llvm.org/noble/",
+                codename=f"llvm-toolchain-noble-{version}",
+                components="main",
+            )
+            rc = _add_apt_repo(repo)
+            assert rc == 0, f"failed adding v{version}"
+
+        content = target_file.read_text()
+        for v in ("19", "20", "21", "22"):
+            assert f"llvm-toolchain-noble-{v}" in content, (
+                f"v{v} entry missing — writer clobbered earlier versions"
+            )
+
+    def test_idempotent_when_exact_line_already_present(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Second call with identical repo is a no-op (not a duplicate line)."""
+        fake_keyring = tmp_path / "llvm.gpg"
+        fake_keyring.write_bytes(b"fake-key")
+        sources_list, sources_dir = _seed_apt_tree(tmp_path, {})
+        _patch_apt_paths(monkeypatch, sources_list, sources_dir)
+        target_file = sources_dir / "llvm.list"
+
+        writes = {"count": 0}
+
+        def fake_sudo_run(cmd, **kwargs):
+            if cmd[:2] == ["dpkg", "--print-architecture"]:
+                return subprocess.CompletedProcess(cmd, 0, stdout="amd64\n", stderr="")
+            if cmd[:3] == ["sudo", "tee", "-a"]:
+                writes["count"] += 1
+                path = Path(cmd[3])
+                mode = "ab" if path.exists() else "wb"
+                with open(path, mode) as f:
+                    f.write(kwargs.get("input", b""))
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+        monkeypatch.setattr(native_deps.subprocess, "run", fake_sudo_run)
+
+        repo = AptRepo(
+            key_url="https://apt.llvm.org/llvm-snapshot.gpg.key",
+            keyring=str(fake_keyring),
+            url="https://apt.llvm.org/noble/",
+            codename="llvm-toolchain-noble-22",
+            components="main",
+        )
+        assert _add_apt_repo(repo) == 0
+        assert _add_apt_repo(repo) == 0  # no-op
+        assert writes["count"] == 1, "second identical add triggered a write"
+        assert target_file.read_text().count("llvm-toolchain-noble-22") == 1
 
 
 class TestDepGroupLoading:


### PR DESCRIPTION
## Summary

v1.11.0's multi-version toolchain feature broke runner image bake on Debian trixie. Root cause: `_add_apt_repo()` used `tee` (overwrite), so when the expansion loop added four LLVM source lines sharing one keyring, only v22's line survived — v19/v20 came from distro repos anyway (masked by distro), but v21 isn't in trixie, so its packages (\`libclang-21-dev\`, \`bolt-21\`, etc.) became unresolvable.

Surfaced in [run 24700310232](https://github.com/hyperi-io/hyperi-infra/) — Ubuntu noble actually worked (v20/v21 from apt.llvm.org happen to overlap distro sufficiently that bake completed), trixie failed apt-cache.

## Fix

- \`tee -a\` (append) + substring-check for existing line. Multiple \`deb\` lines in one .list sharing one keyring is valid apt syntax.

## Regression tests

- \`test_multi_version_writes_append_not_overwrite\` — four sequential adds all land in the file
- \`test_idempotent_when_exact_line_already_present\` — identical repeat call is no-op, no duplicate line

## Test plan

- [x] 434 tests pass (27 in native_deps, up from 24)
- [x] ruff + format clean
- [ ] Rebuild hyperi-infra runner images against 1.11.1 once released — should succeed on trixie