### PR TITLE
fix(toolchains): drop lldb-N from multi-version (python3-lldb-N conflict)

### DIFF
--- a/src/hyperi_ci/config/toolchains/llvm.yaml
+++ b/src/hyperi_ci/config/toolchains/llvm.yaml
@@ -50,18 +50,19 @@
       url: https://apt.llvm.org/${OS_CODENAME}/
       codename: llvm-toolchain-${OS_CODENAME}-{V}
   # Only coinstallable-across-versions packages are listed here. apt.llvm.org
-  # marks the runtime -dev headers (libc++-N-dev, libc++abi-N-dev,
-  # libomp-N-dev, libunwind-N-dev) with `Conflicts: libc++-x.y-dev` etc., so
-  # at most one version of those may be present. Installing all four
-  # together fails with "held broken packages". BOLT and cargo-pgo do not
-  # require them (they operate on ELF post-link); projects that need libc++
-  # runtime headers install the matching version themselves.
+  # marks the following with `Conflicts: <pkg>-x.y` so at most one version of
+  # each may be installed at a time:
+  #   - libc++-N-dev, libc++abi-N-dev, libomp-N-dev, libunwind-N-dev
+  #   - lldb-N  (via its `python3-lldb-N` dep which declares the conflict)
+  # Installing all four versions together fails with "held broken packages".
+  # BOLT and cargo-pgo do not require them (they operate on ELF post-link);
+  # projects that need lldb or libc++ runtime install the matching version
+  # themselves.
   apt_packages:
     - clang-{V}
     - clang-tools-{V}
     - clangd-{V}
     - lld-{V}
-    - lldb-{V}
     - llvm-{V}
     - llvm-{V}-dev
     - llvm-{V}-tools

--- a/src/hyperi_ci/config/toolchains/llvm.yaml
+++ b/src/hyperi_ci/config/toolchains/llvm.yaml
@@ -70,12 +70,23 @@
     - libclang-rt-{V}-dev
     - bolt-{V}
 
-# Singleton entry: non-coinstallable runtime/debugger packages, pinned to the
-# current latest stable LLVM (22). Gives runner images a complete default
-# toolchain: lldb for debugging, libc++/libc++abi for projects that prefer
-# libc++ over libstdc++, libomp for OpenMP, libunwind for stack traces.
-# Projects that need a different version install it themselves at build time.
-- name: llvm-singleton-default
+# ---- Non-coinstallable toolset: install-on-demand standard ----
+#
+# lldb-N, libc++-N-dev, libc++abi-N-dev, libomp-N-dev, libunwind-N-dev all
+# declare `Conflicts: <pkg>-x.y` (or via a transitive dep that does) — at most
+# one version may be installed concurrently. We cannot bake every version into
+# the runner image.
+#
+# Standard pattern: mark the entry `bake: false`. The `--all` mode (runner
+# image bake) SKIPS such entries entirely; they still install conditionally
+# at CI job time when the project's manifest patterns match. Jobs that need
+# these packages pay the ~5s apt-get cost once per runner pod.
+#
+# The YAML picks ONE version (22) for the single install-on-demand target.
+# Projects that need a different version install it themselves (version N's
+# `-dev` package uninstalls version M's, by apt's Conflicts).
+- name: llvm-non-coinstallable
+  bake: false
   patterns:
     - "Cargo.toml"
     - "[package]"

--- a/src/hyperi_ci/config/toolchains/llvm.yaml
+++ b/src/hyperi_ci/config/toolchains/llvm.yaml
@@ -69,3 +69,36 @@
     - libclang-{V}-dev
     - libclang-rt-{V}-dev
     - bolt-{V}
+
+# Singleton entry: non-coinstallable runtime/debugger packages, pinned to the
+# current latest stable LLVM (22). Gives runner images a complete default
+# toolchain: lldb for debugging, libc++/libc++abi for projects that prefer
+# libc++ over libstdc++, libomp for OpenMP, libunwind for stack traces.
+# Projects that need a different version install it themselves at build time.
+- name: llvm-singleton-default
+  patterns:
+    - "Cargo.toml"
+    - "[package]"
+    - "CMakeLists.txt"
+    - "configure.ac"
+    - "c_std"
+    - "cpp_std"
+  manifest_files:
+    - Cargo.toml
+    - Cargo.lock
+    - CMakeLists.txt
+    - configure.ac
+    - meson.build
+    - .hyperi-ci.yaml
+  dpkg_check: libc++-22-dev
+  apt_repos:
+    - key_url: https://apt.llvm.org/llvm-snapshot.gpg.key
+      keyring: /usr/share/keyrings/llvm.gpg
+      url: https://apt.llvm.org/${OS_CODENAME}/
+      codename: llvm-toolchain-${OS_CODENAME}-22
+  apt_packages:
+    - lldb-22
+    - libc++-22-dev
+    - libc++abi-22-dev
+    - libomp-22-dev
+    - libunwind-22-dev

--- a/src/hyperi_ci/native_deps.py
+++ b/src/hyperi_ci/native_deps.py
@@ -66,7 +66,19 @@ class AptRepo:
 
 @dataclass
 class DepGroup:
-    """A group of related native packages triggered by manifest patterns."""
+    """A group of related native packages triggered by manifest patterns.
+
+    `bake` controls behaviour in `--all` mode (runner image bake):
+      True  (default): install unconditionally — entry ends up pre-baked
+                       into the runner image for every matching category.
+      False:           SKIP in --all mode. The entry still installs
+                       conditionally at CI job time when manifest patterns
+                       match. Use for non-coinstallable toolsets (e.g.
+                       `libc++-N-dev` and friends declare Conflicts:x.y,
+                       so only one version may be present at a time —
+                       baking a default would lock out jobs needing a
+                       different version).
+    """
 
     name: str
     patterns: list[str]
@@ -75,6 +87,7 @@ class DepGroup:
     apt_packages: list[str] = field(default_factory=list)
     apt_repos: list[AptRepo] = field(default_factory=list)
     dpkg_min_version: str = ""
+    bake: bool = True
 
 
 _DEFAULT_LLVM_VERSION = "22"
@@ -135,6 +148,7 @@ def _dep_group_from_entry(entry: dict, version: str | None = None) -> DepGroup:
         manifest_files=entry.get("manifest_files", []),
         dpkg_check=sub(entry["dpkg_check"]),
         apt_packages=[sub(p) for p in entry.get("apt_packages", [])],
+        bake=entry.get("bake", True),
         apt_repos=[
             AptRepo(
                 key_url=r["key_url"],
@@ -478,7 +492,19 @@ def install_native_deps(
 
     needed: list[DepGroup] = []
     for group in dep_groups:
-        if not all_mode:
+        if all_mode:
+            # --all mode bypasses manifest match, but entries marked
+            # `bake: false` are ALWAYS install-on-demand — runner image
+            # bake skips them. Non-coinstallable toolsets (one version
+            # at a time) use this; baking a default would lock out jobs
+            # that need a different version.
+            if not group.bake:
+                logger.info(
+                    f"[{group.name}] skipped in --all (bake: false, "
+                    "install-on-demand only)"
+                )
+                continue
+        else:
             # Conditional mode: only install if a manifest pattern matches
             content = _read_manifests(cwd, group.manifest_files)
             if not content:
@@ -638,7 +664,8 @@ def print_needed(
 
     for group in dep_groups:
         if all_mode:
-            matched = True
+            # --all skips bake: false entries (install-on-demand only)
+            matched = group.bake
         else:
             content = _read_manifests(cwd, group.manifest_files)
             matched = bool(content) and _patterns_match(content, group.patterns)

--- a/tests/unit/test_native_deps.py
+++ b/tests/unit/test_native_deps.py
@@ -395,34 +395,145 @@ class TestMultiVersionToolchains:
     ) -> None:
         monkeypatch.setenv("OS_CODENAME", "noble")
         groups = _load_dep_groups("llvm", category="toolchains")
-        # LLVM YAML: versions [19,20,21,22] expand to 4 + 1 singleton
-        # (non-coinstallable runtime pinned to v22) = 5 total
+        # LLVM YAML: versions [19,20,21,22] expand to 4 coinstallable groups
+        # plus 1 non-coinstallable singleton (bake: false) = 5 total.
         multi_names = [g.name for g in groups if g.name.startswith("llvm-toolchain v")]
-        singleton_names = [g.name for g in groups if g.name == "llvm-singleton-default"]
+        singleton_names = [g.name for g in groups if g.name == "llvm-non-coinstallable"]
         assert multi_names == [
             "llvm-toolchain v19",
             "llvm-toolchain v20",
             "llvm-toolchain v21",
             "llvm-toolchain v22",
         ]
-        assert singleton_names == ["llvm-singleton-default"]
+        assert singleton_names == ["llvm-non-coinstallable"]
         assert len(groups) == 5
 
-    def test_llvm_singleton_has_only_non_coinstallable_packages(
+    def test_llvm_non_coinstallable_entry_is_install_on_demand(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """The singleton bundles the packages that can't multi-version install."""
+        """The non-coinstallable entry bundles the one-version-only packages.
+
+        Marked bake: false — skipped in --all mode (runner image), installed
+        conditionally at CI job time when manifest patterns match.
+        """
         monkeypatch.setenv("OS_CODENAME", "noble")
         groups = _load_dep_groups("llvm", category="toolchains")
-        singleton = next(g for g in groups if g.name == "llvm-singleton-default")
+        non_coinst = next(g for g in groups if g.name == "llvm-non-coinstallable")
         # These all declare Conflicts: <pkg>-x.y on apt.llvm.org
-        assert "lldb-22" in singleton.apt_packages
-        assert "libc++-22-dev" in singleton.apt_packages
-        assert "libc++abi-22-dev" in singleton.apt_packages
-        assert "libomp-22-dev" in singleton.apt_packages
-        assert "libunwind-22-dev" in singleton.apt_packages
-        # Singleton must NOT include the coinstallable multi-version packages
-        assert "clang-22" not in singleton.apt_packages
+        assert "lldb-22" in non_coinst.apt_packages
+        assert "libc++-22-dev" in non_coinst.apt_packages
+        assert "libc++abi-22-dev" in non_coinst.apt_packages
+        assert "libomp-22-dev" in non_coinst.apt_packages
+        assert "libunwind-22-dev" in non_coinst.apt_packages
+        # Entry must NOT include the coinstallable multi-version packages
+        assert "clang-22" not in non_coinst.apt_packages
+        # Most importantly: marked install-on-demand
+        assert non_coinst.bake is False
+
+
+class TestBakeFlag:
+    """`bake: false` skips an entry in --all mode regardless of category.
+
+    Standard pattern for toolsets that only support one version at a time
+    (libc++-N-dev, lldb-N, etc. declare Conflicts:x.y on apt.llvm.org).
+    Applies to ANY YAML entry in any category.
+    """
+
+    def test_bake_defaults_to_true_when_key_absent(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Existing YAMLs without a `bake` key stay unconditionally baked."""
+        monkeypatch.setenv("OS_CODENAME", "noble")
+        groups = _load_dep_groups("llvm", category="toolchains")
+        multi = next(g for g in groups if g.name == "llvm-toolchain v22")
+        assert multi.bake is True
+
+    def test_all_mode_skips_bake_false_entries(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        """--all mode installs bake:true entries, skips bake:false."""
+        bogus_dir = tmp_path / "toolchains"
+        bogus_dir.mkdir()
+        (bogus_dir / "pair.yaml").write_text(
+            "- name: always-bake\n"
+            "  patterns: []\n"
+            "  manifest_files: []\n"
+            "  dpkg_check: 'clang-22'\n"
+            "  apt_packages:\n"
+            "    - 'clang-22'\n"
+            "- name: never-bake\n"
+            "  bake: false\n"
+            "  patterns: []\n"
+            "  manifest_files: []\n"
+            "  dpkg_check: 'lldb-22'\n"
+            "  apt_packages:\n"
+            "    - 'lldb-22'\n"
+        )
+        monkeypatch.setitem(native_deps._CATEGORY_DIRS, "toolchains", bogus_dir)
+        monkeypatch.setattr(native_deps.platform, "system", lambda: "Linux")
+
+        installed: list[str] = []
+
+        def fake_apt_install(packages: list[str]) -> int:
+            installed.extend(packages)
+            return 0
+
+        monkeypatch.setattr(native_deps, "_apt_install", fake_apt_install)
+        monkeypatch.setattr(
+            native_deps, "_is_dpkg_installed", lambda pkg, min_v="": False
+        )
+        monkeypatch.setattr(native_deps, "_add_apt_repo", lambda repo: 0)
+
+        rc = native_deps.install_native_deps(
+            "pair", project_dir=tmp_path, category="toolchains", all_mode=True
+        )
+        assert rc == 0
+        assert "clang-22" in installed  # bake: true default
+        assert "lldb-22" not in installed  # bake: false skipped
+
+    def test_conditional_mode_ignores_bake_flag(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        """Conditional mode installs based on patterns regardless of bake flag."""
+        bogus_dir = tmp_path / "toolchains"
+        bogus_dir.mkdir()
+        (bogus_dir / "pair.yaml").write_text(
+            "- name: never-bake\n"
+            "  bake: false\n"
+            "  patterns:\n"
+            "    - 'trigger-me'\n"
+            "  manifest_files:\n"
+            "    - 'Trigger.toml'\n"
+            "  dpkg_check: 'lldb-22'\n"
+            "  apt_packages:\n"
+            "    - 'lldb-22'\n"
+        )
+        (tmp_path / "Trigger.toml").write_text("trigger-me here\n")
+        monkeypatch.setitem(native_deps._CATEGORY_DIRS, "toolchains", bogus_dir)
+        monkeypatch.setattr(native_deps.platform, "system", lambda: "Linux")
+
+        installed: list[str] = []
+
+        def fake_apt_install(packages: list[str]) -> int:
+            installed.extend(packages)
+            return 0
+
+        monkeypatch.setattr(native_deps, "_apt_install", fake_apt_install)
+        monkeypatch.setattr(
+            native_deps, "_is_dpkg_installed", lambda pkg, min_v="": False
+        )
+        monkeypatch.setattr(native_deps, "_add_apt_repo", lambda repo: 0)
+
+        # all_mode=False (conditional) — bake flag does NOT affect the decision
+        rc = native_deps.install_native_deps(
+            "pair", project_dir=tmp_path, category="toolchains", all_mode=False
+        )
+        assert rc == 0
+        assert "lldb-22" in installed  # pattern matched → installed regardless of bake
 
     def test_substitutes_version_in_dpkg_check_and_packages(
         self, monkeypatch: pytest.MonkeyPatch

--- a/tests/unit/test_native_deps.py
+++ b/tests/unit/test_native_deps.py
@@ -395,15 +395,34 @@ class TestMultiVersionToolchains:
     ) -> None:
         monkeypatch.setenv("OS_CODENAME", "noble")
         groups = _load_dep_groups("llvm", category="toolchains")
-        # LLVM YAML declares versions [19, 20, 21, 22] → 4 groups
-        assert len(groups) == 4
-        names = [g.name for g in groups]
-        assert names == [
+        # LLVM YAML: versions [19,20,21,22] expand to 4 + 1 singleton
+        # (non-coinstallable runtime pinned to v22) = 5 total
+        multi_names = [g.name for g in groups if g.name.startswith("llvm-toolchain v")]
+        singleton_names = [g.name for g in groups if g.name == "llvm-singleton-default"]
+        assert multi_names == [
             "llvm-toolchain v19",
             "llvm-toolchain v20",
             "llvm-toolchain v21",
             "llvm-toolchain v22",
         ]
+        assert singleton_names == ["llvm-singleton-default"]
+        assert len(groups) == 5
+
+    def test_llvm_singleton_has_only_non_coinstallable_packages(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The singleton bundles the packages that can't multi-version install."""
+        monkeypatch.setenv("OS_CODENAME", "noble")
+        groups = _load_dep_groups("llvm", category="toolchains")
+        singleton = next(g for g in groups if g.name == "llvm-singleton-default")
+        # These all declare Conflicts: <pkg>-x.y on apt.llvm.org
+        assert "lldb-22" in singleton.apt_packages
+        assert "libc++-22-dev" in singleton.apt_packages
+        assert "libc++abi-22-dev" in singleton.apt_packages
+        assert "libomp-22-dev" in singleton.apt_packages
+        assert "libunwind-22-dev" in singleton.apt_packages
+        # Singleton must NOT include the coinstallable multi-version packages
+        assert "clang-22" not in singleton.apt_packages
 
     def test_substitutes_version_in_dpkg_check_and_packages(
         self, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
lldb-N transitively installs python3-lldb-N which declares Conflicts: python3-lldb-x.y, so multi-version LLDB fails with 'held broken packages'. BOLT/PGO don't need lldb. Drop from multi-version YAML. Verified: full coinstallable v19/20/21/22 install now succeeds on trixie-slim.