### PR TITLE
fix: add optional submodules input to python-ci (#39)

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -52,6 +52,10 @@ on:
         type: string
         default: "auto"
         description: "Version resolution for from-head: auto | patch | minor (forced)."
+      submodules:
+        type: string
+        default: ""
+        description: "Space-separated submodule paths to init after checkout (e.g. 'schemas'). Empty (default) inits nothing. The submodule must be reachable by the job token -- public, or a token with cross-repo read access."
     secrets:
       JFROG_TOKEN:
         required: false
@@ -231,6 +235,12 @@ jobs:
 
       - name: Install dependencies
         run: uv sync --frozen --all-extras
+
+      - name: Init submodules
+        if: ${{ inputs.submodules != '' }}
+        env:
+          SUBMODULES: ${{ inputs.submodules }}
+        run: git submodule update --init --depth 1 $SUBMODULES
 
       - name: Run tests
         run: ${{ env.HYPERCI_INSTALL }} run test

--- a/docs/LESSONS.md
+++ b/docs/LESSONS.md
@@ -299,9 +299,13 @@ build to ensure fresh artifacts, also via `hyperi-ci run build`.
 - Detection: directory-based > marker-based > conftest-based
 - Coverage: separate `.coverage.<tier>` files, combine at end
 - No test directory: exit 0 (graceful skip)
-- Private submodules (e.g. `dfe-schemas`): mark dependent tests with
-  `@pytest.mark.skipif(not schemas_dir.exists(), reason="submodule not checked out")`
-  rather than trying to check out private submodules in CI (GITHUB_TOKEN can't)
+- Submodule-dependent tests:
+  - Public submodule: set the `submodules` input on the reusable workflow
+    (e.g. `submodules: schemas`) so CI checks it out and the tests run.
+  - Private submodule (e.g. `dfe-schemas` while private): GITHUB_TOKEN can't
+    clone it, so mark dependent tests with
+    `@pytest.mark.skipif(not schemas_dir.exists(), reason="submodule not checked out")`
+    rather than checking it out in CI (or wire a cross-repo token).
 
 ### Publishing
 


### PR DESCRIPTION
Refs #39.

## What

Adds an optional `submodules` input to the reusable `python-ci.yml`. When set (e.g. `submodules: schemas`), the `test` job runs `git submodule update --init --depth 1 <paths>` after checkout (value passed via env to avoid script injection). Default empty -> a no-op for every current consumer.

## Why

Consumer tests that read submodule content currently fail in CI because the reusable-workflow checkout fetches no submodules. Concretely: `dfe-engine` resolves ClickHouse schema profiles from its `schemas` submodule (`schemas/common-header/*.yaml`) and falls back to stale bundled profiles when it is absent, so a `1.1.0` profile test fails in CI while passing locally.

## Scope / constraints

- `python-ci.yml` only for now (the dfe-engine case). Easy to extend to the other language workflows if needed -- see #39.
- Init lives in the `test` job, the only one that consumes submodule content (quality lints `src/`, build packages `src/`).
- Works for a **public** submodule with the default `GITHUB_TOKEN`. A **private** submodule still can't be cloned by the default token -- those keep using the `skipif` pattern (or a configured cross-repo token).

## Docs

- `docs/LESSONS.md` reconciled: `skipif` for private submodules; the `submodules` input for public ones.

## Verification

- `tests/unit/test_workflow_consistency.py`: 45 passed (YAML valid, gates/threading intact).
- Default-empty input means no behaviour change for any repo that doesn't opt in.

## Consumer opt-in (after merge)

A repo with a public submodule adds to its `ci.yml`:

```yaml
    with:
      submodules: schemas
```
