### PR TITLE
fix: scaffold submodules input in consumer ci.yml (#39)

### DIFF
--- a/docs/LESSONS.md
+++ b/docs/LESSONS.md
@@ -300,8 +300,9 @@ build to ensure fresh artifacts, also via `hyperi-ci run build`.
 - Coverage: separate `.coverage.<tier>` files, combine at end
 - No test directory: exit 0 (graceful skip)
 - Submodule-dependent tests:
-  - Public submodule: set the `submodules` input on the reusable workflow
-    (e.g. `submodules: schemas`) so CI checks it out and the tests run.
+  - Public submodule: declare `submodules: schemas` in `.hyperi-ci.yaml`;
+    `hyperi-ci init` renders it as the reusable-workflow `submodules` input
+    in `ci.yml`, and the test job checks it out so the tests run.
   - Private submodule (e.g. `dfe-schemas` while private): GITHUB_TOKEN can't
     clone it, so mark dependent tests with
     `@pytest.mark.skipif(not schemas_dir.exists(), reason="submodule not checked out")`

--- a/src/hyperi_ci/init.py
+++ b/src/hyperi_ci/init.py
@@ -112,6 +112,26 @@ def detect_license(project_dir: Path) -> str:
     return _DEFAULT_LICENSE
 
 
+def _detect_submodules(project_dir: Path) -> str:
+    """Read the ``submodules`` field from ``.hyperi-ci.yaml`` (else "").
+
+    Names submodule paths the CI test job should init (space-separated),
+    e.g. ``schemas``. Threaded into both the generated ci.yml (the
+    reusable-workflow ``submodules`` input) and the regenerated
+    ``.hyperi-ci.yaml``, so the value survives re-init.
+    """
+    ci_config = project_dir / ".hyperi-ci.yaml"
+    if ci_config.exists():
+        try:
+            data = yaml.safe_load(ci_config.read_text()) or {}
+            declared = data.get("submodules") if isinstance(data, dict) else None
+            if isinstance(declared, str) and declared.strip():
+                return declared.strip()
+        except (OSError, UnicodeDecodeError, yaml.YAMLError):
+            pass
+    return ""
+
+
 def _license_header_text(license_id: str) -> str:
     """Return the license line for file headers."""
     if license_id == "BUSL-1.1":
@@ -169,6 +189,7 @@ def _render_hyperi_ci_yaml(
     project_name: str,
     project_dir: Path,
     license_id: str = _DEFAULT_LICENSE,
+    submodules: str = "",
 ) -> str:
     """Render .hyperi-ci.yaml with language-specific defaults."""
     config: dict = {
@@ -218,6 +239,11 @@ def _render_hyperi_ci_yaml(
     elif language == "typescript":
         config["test"]["coverage"] = True
         config["typescript"] = {"package_manager": "auto"}
+
+    # Submodule paths the CI test job inits (space-separated, e.g. "schemas").
+    # Emitted as the reusable-workflow `submodules` input in ci.yml.
+    if submodules:
+        config["submodules"] = submodules
 
     header = (
         f"# Project:   {project_name}\n"
@@ -269,6 +295,7 @@ def _render_workflow(
     workflow_file: str,
     license_id: str = _DEFAULT_LICENSE,
     publish_target: str = "internal",
+    submodules: str = "",
 ) -> str:
     """Render consumer .github/workflows/ci.yml content."""
     base = (
@@ -316,6 +343,9 @@ def _render_workflow(
 
     if publish_target != "internal":
         base += f"      publish-target: {publish_target}\n"
+
+    if submodules:
+        base += f"      submodules: {submodules}\n"
 
     base += "    secrets: inherit\n"
     return base
@@ -564,6 +594,7 @@ def init_project(
         return 1
 
     license_id = detect_license(project_dir)
+    submodules = _detect_submodules(project_dir)
     info(f"Initialising {project_name} as {detected} project (license: {license_id})")
 
     workflow_file = _LANGUAGE_WORKFLOW_MAP.get(detected)
@@ -578,6 +609,7 @@ def init_project(
         project_name,
         project_dir,
         license_id=license_id,
+        submodules=submodules,
     )
     config_path = project_dir / ".hyperi-ci.yaml"
     if _write_file(config_path, config_content, force=force):
@@ -600,6 +632,7 @@ def init_project(
             project_name,
             workflow_file,
             license_id=license_id,
+            submodules=submodules,
         )
         workflow_path = project_dir / ".github" / "workflows" / "ci.yml"
         if _write_file(


### PR DESCRIPTION
Refs #39. Scaffold half of the `submodules` story (PR #40 added the workflow input).

## Problem

`hyperi-ci init` -> `_render_workflow()` only emits `tag` / `from-head` / `bump` (plus optional `publish-target`) into the generated consumer `ci.yml`. So the `submodules` input from #40 never reaches a consumer through the scaffold, and a hand-added `submodules:` line is clobbered on the next `init --force`.

## Change

- `init` reads a `submodules:` field from `.hyperi-ci.yaml` (`_detect_submodules`, mirroring `detect_license`).
- `_render_workflow` emits `submodules: <value>` into the `with:` block when set (mirrors the existing `publish-target` conditional).
- `_render_hyperi_ci_yaml` round-trips the field, so re-init preserves it.
- Runtime-safe: `CIConfig` is `.get()`-based with no strict validation, so the new key is ignored by the config loader -- it's init-only.
- `docs/LESSONS.md`: the public-submodule path now points at the `.hyperi-ci.yaml` field + `init` render.

## Result

`.hyperi-ci.yaml`:

```yaml
submodules: schemas
```

`hyperi-ci init` renders `ci.yml`:

```yaml
    with:
      tag: ${{ inputs.tag || '' }}
      from-head: ${{ inputs.from-head || '' }}
      bump: ${{ inputs.bump || 'auto' }}
      submodules: schemas
    secrets: inherit
```

## Verification

- `tests/unit/test_init.py`: 51 passed.
- Field declared in `.hyperi-ci.yaml` is ignored by the runtime config loader (confirmed `CIConfig` reads only known keys).

Together with #40, a consumer with a public submodule sets one field in `.hyperi-ci.yaml` and re-runs `hyperi-ci init` -- no manual workflow editing.
