### PR TITLE
fix: resolve Tier 2 generate producer via uv run

### DIFF
--- a/src/hyperi_ci/deployment/stage.py
+++ b/src/hyperi_ci/deployment/stage.py
@@ -213,6 +213,17 @@ def _run_tier2(output_dir: Path, project_dir: Path) -> int:
     ``Application.deployment_contract()`` emits artefacts from. If
     multiple scripts are declared, the first one wins.
 
+    The entry point is installed into the project's uv-managed virtualenv
+    (via ``uv sync``), not the global ``PATH`` — so a bare ``PATH`` lookup
+    fails under ``uvx hyperi-ci run generate`` in CI, where the venv is
+    never activated. When ``uv`` is available we invoke through
+    ``uv run``, which resolves the script in the project environment
+    regardless of activation and respects ``UV_PROJECT_ENVIRONMENT``.
+    ``--frozen`` keeps the lockfile untouched (matching the workflow's
+    ``uv sync --frozen``, so generate can't mutate the lock). Falls back
+    to a ``PATH`` lookup when ``uv`` is absent but the script is installed
+    globally.
+
     Until hyperi-pylib ships its mirror of the rustlib deployment
     module (parallel work; not yet started), even an installed entry
     point will fail with no ``generate-artefacts`` subcommand. That
@@ -227,12 +238,31 @@ def _run_tier2(output_dir: Path, project_dir: Path) -> int:
         )
         return EXIT_PRODUCER_MISSING
 
+    uv = shutil.which("uv")
+    if uv is not None:
+        info(f"Generate (Tier 2): running uv run {script_name} generate-artefacts")
+        cmd = [
+            uv,
+            "run",
+            "--frozen",
+            "--project",
+            str(project_dir),
+            script_name,
+            "generate-artefacts",
+            "--output-dir",
+            str(output_dir),
+        ]
+        return _run_producer_subprocess(cmd, "Python")
+
     binary = shutil.which(script_name)
     if binary is None:
-        error(f"Generate (Tier 2): {script_name!r} not on PATH.")
+        error(
+            f"Generate (Tier 2): {script_name!r} not resolvable — "
+            "uv not on PATH and no globally installed script."
+        )
         info(
-            f"Run `uv sync --project {project_dir}` "
-            f"(or `pip install -e {project_dir}`) first."
+            f"Install uv (recommended), or run `uv sync --project {project_dir}` "
+            f"(or `pip install -e {project_dir}`) so {script_name!r} resolves."
         )
         return EXIT_PRODUCER_MISSING
 

--- a/tests/unit/deployment/test_stage.py
+++ b/tests/unit/deployment/test_stage.py
@@ -312,13 +312,33 @@ class TestRustBinaryName:
 
 
 class TestTier2:
-    """Tier 2 (python + pylib) routes through PATH lookup."""
+    """Tier 2 (python + pylib) invokes the entry point via uv run.
 
-    def test_entry_point_not_on_path_returns_producer_missing(
+    The producer entry point lives in the project's uv venv, not on
+    PATH, so the stage prefers ``uv run`` and only falls back to a bare
+    PATH lookup when uv is absent.
+    """
+
+    def test_uv_run_invoked_when_uv_present(self, tmp_path: Path, monkeypatch) -> None:
+        _write_tier2_repo(tmp_path)
+        # Fake `uv` on PATH that succeeds for any args — isolates the test
+        # from a real uv/venv while exercising the uv-run producer path.
+        bindir = tmp_path / "fakebin"
+        bindir.mkdir()
+        uv = bindir / "uv"
+        uv.write_text('#!/usr/bin/env bash\nexit 0\n', encoding="utf-8")
+        os.chmod(uv, uv.stat().st_mode | stat.S_IXUSR)
+        # Prepend so the fake uv wins shutil.which while bash stays resolvable.
+        monkeypatch.setenv("PATH", f"{bindir}{os.pathsep}{os.environ['PATH']}")
+        rc = run(output_dir=tmp_path / "ci-tmp", project_dir=tmp_path)
+        # Fake uv exits 0 → producer succeeded.
+        assert rc == EXIT_OK
+
+    def test_entry_point_unresolvable_returns_producer_missing(
         self, tmp_path: Path, monkeypatch
     ) -> None:
         _write_tier2_repo(tmp_path)
-        # Empty PATH so shutil.which can't find demo-app.
+        # Empty PATH: neither uv nor the demo-app script is resolvable.
         monkeypatch.setenv("PATH", str(tmp_path / "no-such-bin"))
         rc = run(output_dir=tmp_path / "ci-tmp", project_dir=tmp_path)
         assert rc == EXIT_PRODUCER_MISSING


### PR DESCRIPTION
## What

The `generate` stage's Tier 2 (Python/pylib) path resolved the app entry point with a bare `shutil.which(<script>)`. Under `uvx hyperi-ci run generate` in CI the project's uv venv is never on PATH, so the script wasn't found and the stage returned `EXIT_PRODUCER_MISSING` (exit 7) even after `uv sync` installed it into `.venv/bin`.

This invokes the producer via `uv run --frozen --project <dir> <script> generate-artefacts`, which resolves the entry point in the project environment regardless of venv activation (and respects `UV_PROJECT_ENVIRONMENT`). The bare PATH lookup remains as a fallback when uv is absent.

## Verification

- New unit test for the uv-run path; full unit suite (912) passes; ruff clean.
- Verified end-to-end against dfe-engine: the previously-failing stage now emits `deployment-contract.json`, `container-manifest.json`, `Dockerfile.runtime`, `argocd-application.yaml` and returns success.

Closes #46