### PR TITLE
fix: TypeScript monorepo support (yarn-berry audit + Dockerfile detect)

### DIFF
--- a/src/hyperi_ci/container/detect.py
+++ b/src/hyperi_ci/container/detect.py
@@ -66,14 +66,19 @@ def detect(
         ``Decision`` describing the outcome.
 
     """
-    if _is_library(language=language, project_dir=project_dir):
-        return Decision(build=False, reason=f"{language} project is library-only")
-
+    # An explicit Dockerfile is an unambiguous "ship a container" signal
+    # and must win over the library heuristic — otherwise a monorepo root
+    # with a Dockerfile (whose runnable start script lives in a workspace,
+    # not the root package.json) is wrongly declared library-only and the
+    # Dockerfile is never used.
     dockerfile_path = project_dir / dockerfile
     if dockerfile_path.exists():
         return Decision(
             build=True, reason=f"Dockerfile found at {dockerfile}", mode="custom"
         )
+
+    if _is_library(language=language, project_dir=project_dir):
+        return Decision(build=False, reason=f"{language} project is library-only")
 
     if language == "rust" and _rust_supports_contract(project_dir):
         return Decision(
@@ -208,6 +213,12 @@ def _typescript_is_library(project_dir: Path) -> bool:
     except json.JSONDecodeError:
         return False
     if manifest.get("bin"):
+        return False
+    # A ``workspaces`` field means this is a monorepo root, not a plain
+    # library: the runnable ``start``/``serve``/``server`` script lives in
+    # a workspace package (e.g. ``apps/<app>/package.json``), so the root
+    # legitimately has none. Treat the root as a runnable, not a library.
+    if manifest.get("workspaces"):
         return False
     scripts = manifest.get("scripts", {})
     for key in ("start", "serve", "server"):

--- a/src/hyperi_ci/languages/typescript/quality.py
+++ b/src/hyperi_ci/languages/typescript/quality.py
@@ -25,6 +25,7 @@ from hyperi_ci.common import error, info, success, warn
 from hyperi_ci.config import CIConfig
 from hyperi_ci.languages.typescript._common import (
     detect_package_manager,
+    detect_yarn_version,
     ensure_pm_available,
 )
 from hyperi_ci.quality import osv_scanner
@@ -161,6 +162,32 @@ def _run_tool(
     return False
 
 
+def _audit_command(*, audit_level: str, pm: str, yarn_major: int) -> list[str]:
+    """Build the security-audit command for the package manager.
+
+    Yarn Berry (v2+) removed ``yarn audit`` in favour of ``yarn npm
+    audit --severity <level>``; running the Classic ``yarn audit
+    --audit-level`` there exits non-zero. Yarn Classic (v1) keeps
+    ``yarn audit --audit-level``. npm and pnpm both take
+    ``--audit-level``.
+
+    Args:
+        audit_level: Minimum severity to fail on (e.g. ``"moderate"``).
+        pm: Package manager — one of ``npm``, ``yarn``, ``pnpm``.
+        yarn_major: Yarn major version; only consulted when ``pm`` is
+            ``yarn``. ``>= 2`` selects the Berry command.
+
+    Returns:
+        The audit command as an argv list.
+
+    """
+    if pm == "yarn" and yarn_major >= 2:
+        return ["yarn", "npm", "audit", "--severity", audit_level]
+    if pm == "yarn":
+        return ["yarn", "audit", f"--audit-level={audit_level}"]
+    return [pm, "audit", f"--audit-level={audit_level}"]
+
+
 def run(config: CIConfig, extra_env: dict[str, str] | None = None) -> int:
     """Run TypeScript/JavaScript quality checks.
 
@@ -234,7 +261,8 @@ def run(config: CIConfig, extra_env: dict[str, str] | None = None) -> int:
     # --- audit + semgrep — run on any JS/TS project; orthogonal to npm scripts ---
     mode = _get_tool_mode("audit", config)
     audit_level = config.get("quality.typescript.audit_level", "moderate")
-    audit_cmd = [pm, "audit", f"--audit-level={audit_level}"]
+    yarn_major = detect_yarn_version() if pm == "yarn" else 0
+    audit_cmd = _audit_command(audit_level=audit_level, pm=pm, yarn_major=yarn_major)
     audit_ignores = for_tool(ignores, f"{pm}-audit")
     if audit_ignores:
         if pm == "pnpm":

--- a/tests/unit/test_container_detect.py
+++ b/tests/unit/test_container_detect.py
@@ -164,6 +164,44 @@ def test_typescript_with_start_script_uses_template(tmp_path: Path) -> None:
     assert decision.build is True
 
 
+def test_typescript_library_with_dockerfile_builds_custom(tmp_path: Path) -> None:
+    # A library-shaped root (no bin/start, main -> dist/lib.js) that
+    # nonetheless ships a Dockerfile must build — the explicit Dockerfile
+    # wins over the library heuristic (issue #45).
+    _write_package_json(
+        tmp_path,
+        {"name": "mylib", "version": "0.1.0", "main": "dist/lib.js"},
+    )
+    (tmp_path / "Dockerfile").write_text("FROM node:22-alpine\n")
+    decision = detect(language="typescript", project_dir=tmp_path)
+    assert decision.build is True
+    assert decision.mode == "custom"
+
+
+def test_typescript_monorepo_root_with_dockerfile_builds(tmp_path: Path) -> None:
+    # Turborepo root: runnable start lives in a workspace, root has no
+    # start script — but a root Dockerfile must still trigger the build.
+    _write_package_json(
+        tmp_path,
+        {"name": "root", "private": True, "workspaces": ["apps/*", "packages/*"]},
+    )
+    (tmp_path / "Dockerfile").write_text("FROM node:22-alpine\n")
+    decision = detect(language="typescript", project_dir=tmp_path)
+    assert decision.build is True
+    assert decision.mode == "custom"
+
+
+def test_typescript_monorepo_root_is_not_library(tmp_path: Path) -> None:
+    # A `workspaces` root with no start script and no Dockerfile is a
+    # monorepo, not a plain library — it should build (template), not skip.
+    _write_package_json(
+        tmp_path,
+        {"name": "root", "private": True, "workspaces": ["apps/*"]},
+    )
+    decision = detect(language="typescript", project_dir=tmp_path)
+    assert decision.build is True
+
+
 # --- Go ------------------------------------------------------------------
 
 

--- a/tests/unit/test_typescript_quality.py
+++ b/tests/unit/test_typescript_quality.py
@@ -200,3 +200,30 @@ class TestPureJsProjectEndToEnd:
         # Non-zero only if audit/semgrep actually failed in real env;
         # with our mocked zero return they succeed
         assert rc == 0
+
+
+class TestAuditCommand:
+    """`_audit_command` builds the right invocation per package manager."""
+
+    @pytest.mark.parametrize(
+        ("pm", "yarn_major", "expected"),
+        [
+            ("npm", 0, ["npm", "audit", "--audit-level=moderate"]),
+            ("pnpm", 0, ["pnpm", "audit", "--audit-level=moderate"]),
+            ("yarn", 1, ["yarn", "audit", "--audit-level=moderate"]),
+            ("yarn", 2, ["yarn", "npm", "audit", "--severity", "moderate"]),
+            ("yarn", 4, ["yarn", "npm", "audit", "--severity", "moderate"]),
+        ],
+    )
+    def test_command_per_package_manager(
+        self, pm: str, yarn_major: int, expected: list[str]
+    ) -> None:
+        cmd = quality._audit_command(
+            audit_level="moderate", pm=pm, yarn_major=yarn_major
+        )
+        assert cmd == expected
+
+    def test_audit_level_is_threaded_through(self) -> None:
+        assert quality._audit_command(
+            audit_level="high", pm="yarn", yarn_major=4
+        ) == ["yarn", "npm", "audit", "--severity", "high"]


### PR DESCRIPTION
Two related TypeScript/Turborepo monorepo fixes (both surfaced from dfe-ui).

## #44 — yarn-berry audit

The TS audit stage hardcoded `[pm, "audit", "--audit-level=<lvl>"]`. Yarn Berry (v2+) removed `yarn audit`; the correct command is `yarn npm audit --severity <lvl>`, so Berry consumers failed the blocking audit locally. Adds `_audit_command()` picking the right invocation per package manager and yarn major version (Berry -> `yarn npm audit --severity`; Classic/npm/pnpm -> `--audit-level`).

## #45 — explicit Dockerfile ignored / monorepo root misdetected

`container/detect.py::detect()` ran `_is_library()` before checking for a Dockerfile, so a monorepo root with a Dockerfile (whose runnable start script lives in a workspace, not the root `package.json`) was declared library-only and never built. Now the configured Dockerfile path is checked first, and a `package.json` `workspaces` field marks the root as not-a-library so a Turborepo root builds via template too.

## Verification

New unit tests: `_audit_command` per package manager + yarn version; Dockerfile-precedence and workspace-aware detection. Full unit suite (921) passes; ruff clean.

Closes #44
Closes #45