### PR TITLE
fix: per-artefact publish opt-out (container-only for private Python services)

### DIFF
--- a/src/hyperi_ci/config.py
+++ b/src/hyperi_ci/config.py
@@ -102,6 +102,12 @@ class CIConfig:
     def destination_for(self, artifact_type: str) -> list[str]:
         """Get publish destination(s) for a specific artifact type.
 
+        A falsy destination (``false`` / ``null`` / empty) is treated as an
+        opt-out and skipped, so a project can drop one artefact from
+        publishing while keeping the rest — e.g. a private Python service
+        that ships only its GHCR container sets
+        ``publish.destinations_oss.python: false``.
+
         Args:
             artifact_type: One of python, npm, cargo, container, helm, binaries, go.
 
@@ -112,7 +118,7 @@ class CIConfig:
         return [
             dest[artifact_type]
             for dest in self.publish_destinations()
-            if artifact_type in dest
+            if artifact_type in dest and dest[artifact_type]
         ]
 
 

--- a/src/hyperi_ci/config/defaults.yaml
+++ b/src/hyperi_ci/config/defaults.yaml
@@ -263,6 +263,10 @@ publish:
   binaries_repo: hyperi-binaries
 
   # Destination mapping (OSS only).
+  #
+  # Set any artefact to `false` in a project's .hyperi-ci.yaml to opt out
+  # of publishing it while keeping the rest — e.g. a private Python service
+  # that ships only its GHCR container sets `python: false`.
   destinations_oss:
     python: pypi               # pypi.org (OIDC Trusted Publishing)
     npm: npmjs                 # npmjs.com @hyperi/* (OIDC)

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -96,6 +96,23 @@ class TestCIConfig:
         assert config.destination_for("python") == ["pypi"]
         assert config.destination_for("container") == ["ghcr"]
 
+    def test_destination_for_falsy_is_opt_out(self) -> None:
+        # A private Python service ships only its GHCR container: python
+        # is opted out with `false`, container still resolves.
+        config = CIConfig(
+            publish_target="oss",
+            _raw={
+                "publish": {
+                    "destinations_oss": {
+                        "python": False,
+                        "container": "ghcr",
+                    },
+                },
+            },
+        )
+        assert config.destination_for("python") == []
+        assert config.destination_for("container") == ["ghcr"]
+
     def test_legacy_target_internal_routes_to_oss(self) -> None:
         """Legacy ``target: internal`` is accepted for back-compat but
         ignored — every publish goes to OSS destinations.


### PR DESCRIPTION
## What

Since v2.1.4 removed internal/JFrog publishing, every artefact routes to `publish.destinations_oss` and there was no way to skip just one. A private Python service whose deliverable is its **GHCR container** had no opt-out for the wheel, so it was forced to public PyPI (unwanted for a private repo, and failing without PyPI creds).

`CIConfig.destination_for()` now skips a **falsy** (`false`/`null`/empty) destination. A project can then set:

```yaml
publish:
  destinations_oss:
    python: false   # skip the wheel; container still -> ghcr
```

to get a container-only release. Also documents the opt-out in `defaults.yaml`.

## Verification

New unit test (`test_destination_for_falsy_is_opt_out`); full unit suite (922) passes; ruff check + format clean.

Closes #49