### PR TITLE
fix: validate commit messages on merge to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,33 @@ jobs:
           from-head: ${{ inputs.from-head }}
           bump: ${{ inputs.bump }}
 
+  commit-check:
+    name: Commit messages
+    # Landing gate for conventional-commit messages -- dogfoods the same job
+    # the reusable <lang>-ci.yml workflows now ship. Deliberately NOT gated on
+    # plan.outputs.run-checks: it must validate what actually reaches main on
+    # EVERY merge, not only publish-worthy pushes. Fatal on push to main (what
+    # lands); advisory on pull_request. Runs the LOCAL branch code (uv run) so
+    # this repo's own PRs exercise the change. See CLAUDE.md CI gate doctrine.
+    if: >-
+      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          enable-cache: true
+      - name: Set up Python
+        run: uv python install 3.12
+      - name: Install dependencies
+        run: uv sync --no-sources
+      - name: Validate commit messages
+        run: uv run --no-sources hyperi-ci check-commits
+
   quality:
     name: Quality
     runs-on: ubuntu-latest

--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -155,6 +155,30 @@ jobs:
           fi
           echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
 
+  commit-check:
+    name: Commit messages
+    # Landing gate for conventional-commit messages. Deliberately NOT gated
+    # on plan.outputs.run-checks: a cheap git-log + regex check must validate
+    # what actually reaches main on EVERY merge, not only publish-worthy
+    # pushes (all the quality job covers). Fatal on push to main (what lands);
+    # advisory on pull_request (branch commits may be squashed away -- see
+    # commit_validation.run). Feature-branch pushes skip it, so the fast
+    # chore-skip path is untouched. See CLAUDE.md CI gate doctrine.
+    if: >-
+      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          enable-cache: false
+      - name: Validate commit messages
+        run: ${{ env.HYPERCI_INSTALL }} check-commits
+
   quality:
     name: Quality
     needs: [plan]
@@ -200,12 +224,11 @@ jobs:
       - name: Install native dependencies
         run: ${{ env.HYPERCI_INSTALL }} install-native-deps golang
 
-      - name: Deepen history for commit validation
-        # The quality checkout is depth-1; commit validation (issue #52) needs
-        # the pushed range before..after, which includes `before` and any
-        # merge-imported commits. Deepen so the range resolves. Harmless on an
-        # already-full clone. If skipped, the quality stage validates HEAD only
-        # and warns loudly -- it never silently passes having checked nothing.
+      - name: Deepen history for secret scan
+        # gitleaks scans the branch git log for committed secrets; a depth-1
+        # checkout would only see HEAD. Deepen so the scan covers the pushed
+        # range. Conventional-commit validation moved to the commit-check job
+        # (its own fetch-depth: 0 checkout). Harmless on an already-full clone.
         if: ${{ github.event_name == 'push' || github.event_name == 'pull_request' }}
         run: git fetch --deepen=200 origin
 

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -140,6 +140,30 @@ jobs:
           from-head: ${{ inputs.from-head }}
           bump: ${{ inputs.bump }}
 
+  commit-check:
+    name: Commit messages
+    # Landing gate for conventional-commit messages. Deliberately NOT gated
+    # on plan.outputs.run-checks: a cheap git-log + regex check must validate
+    # what actually reaches main on EVERY merge, not only publish-worthy
+    # pushes (all the quality job covers). Fatal on push to main (what lands);
+    # advisory on pull_request (branch commits may be squashed away -- see
+    # commit_validation.run). Feature-branch pushes skip it, so the fast
+    # chore-skip path is untouched. See CLAUDE.md CI gate doctrine.
+    if: >-
+      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          enable-cache: false
+      - name: Validate commit messages
+        run: ${{ env.HYPERCI_INSTALL }} check-commits
+
   quality:
     name: Quality
     needs: [plan]
@@ -174,12 +198,11 @@ jobs:
       - name: Install dependencies
         run: uv sync --frozen --all-extras
 
-      - name: Deepen history for commit validation
-        # The quality checkout is depth-1; commit validation (issue #52) needs
-        # the pushed range before..after, which includes `before` and any
-        # merge-imported commits. Deepen so the range resolves. Harmless on an
-        # already-full clone. If skipped, the quality stage validates HEAD only
-        # and warns loudly -- it never silently passes having checked nothing.
+      - name: Deepen history for secret scan
+        # gitleaks scans the branch git log for committed secrets; a depth-1
+        # checkout would only see HEAD. Deepen so the scan covers the pushed
+        # range. Conventional-commit validation moved to the commit-check job
+        # (its own fetch-depth: 0 checkout). Harmless on an already-full clone.
         if: ${{ github.event_name == 'push' || github.event_name == 'pull_request' }}
         run: git fetch --deepen=200 origin
 

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -173,6 +173,30 @@ jobs:
           fi
           echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
 
+  commit-check:
+    name: Commit messages
+    # Landing gate for conventional-commit messages. Deliberately NOT gated
+    # on plan.outputs.run-checks: a cheap git-log + regex check must validate
+    # what actually reaches main on EVERY merge, not only publish-worthy
+    # pushes (all the quality job covers). Fatal on push to main (what lands);
+    # advisory on pull_request (branch commits may be squashed away -- see
+    # commit_validation.run). Feature-branch pushes skip it, so the fast
+    # chore-skip path is untouched. See CLAUDE.md CI gate doctrine.
+    if: >-
+      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          enable-cache: false
+      - name: Validate commit messages
+        run: ${{ env.HYPERCI_INSTALL }} check-commits
+
   quality:
     name: Quality
     needs: [plan]
@@ -226,12 +250,11 @@ jobs:
       - name: Setup osv-scanner
         uses: hyperi-io/hyperi-ci/.github/actions/setup-osv-scanner@main
 
-      - name: Deepen history for commit validation
-        # The quality checkout is depth-1; commit validation (issue #52) needs
-        # the pushed range before..after, which includes `before` and any
-        # merge-imported commits. Deepen so the range resolves. Harmless on an
-        # already-full clone. If skipped, the quality stage validates HEAD only
-        # and warns loudly -- it never silently passes having checked nothing.
+      - name: Deepen history for secret scan
+        # gitleaks scans the branch git log for committed secrets; a depth-1
+        # checkout would only see HEAD. Deepen so the scan covers the pushed
+        # range. Conventional-commit validation moved to the commit-check job
+        # (its own fetch-depth: 0 checkout). Harmless on an already-full clone.
         if: ${{ github.event_name == 'push' || github.event_name == 'pull_request' }}
         run: git fetch --deepen=200 origin
 

--- a/.github/workflows/ts-ci.yml
+++ b/.github/workflows/ts-ci.yml
@@ -137,6 +137,30 @@ jobs:
           from-head: ${{ inputs.from-head }}
           bump: ${{ inputs.bump }}
 
+  commit-check:
+    name: Commit messages
+    # Landing gate for conventional-commit messages. Deliberately NOT gated
+    # on plan.outputs.run-checks: a cheap git-log + regex check must validate
+    # what actually reaches main on EVERY merge, not only publish-worthy
+    # pushes (all the quality job covers). Fatal on push to main (what lands);
+    # advisory on pull_request (branch commits may be squashed away -- see
+    # commit_validation.run). Feature-branch pushes skip it, so the fast
+    # chore-skip path is untouched. See CLAUDE.md CI gate doctrine.
+    if: >-
+      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          enable-cache: false
+      - name: Validate commit messages
+        run: ${{ env.HYPERCI_INSTALL }} check-commits
+
   quality:
     name: Quality
     needs: [plan]
@@ -197,12 +221,11 @@ jobs:
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
           "$HOME/.local/bin/osv-scanner" --version
 
-      - name: Deepen history for commit validation
-        # The quality checkout is depth-1; commit validation (issue #52) needs
-        # the pushed range before..after, which includes `before` and any
-        # merge-imported commits. Deepen so the range resolves. Harmless on an
-        # already-full clone. If skipped, the quality stage validates HEAD only
-        # and warns loudly -- it never silently passes having checked nothing.
+      - name: Deepen history for secret scan
+        # gitleaks scans the branch git log for committed secrets; a depth-1
+        # checkout would only see HEAD. Deepen so the scan covers the pushed
+        # range. Conventional-commit validation moved to the commit-check job
+        # (its own fetch-depth: 0 checkout). Harmless on an already-full clone.
         if: ${{ github.event_name == 'push' || github.event_name == 'pull_request' }}
         run: git fetch --deepen=200 origin
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -82,10 +82,20 @@ the single place language divergence is allowed.
 | Job | needs | if | Purpose |
 |---|---|---|---|
 | `plan` | — | always | Decide if this run is publish-worthy; emit gate outputs |
+| `commit-check` | — | push-to-main OR `pull_request` | Conventional-commit **landing gate** — fatal on push to main (validates what lands), advisory on PRs. NOT `run-checks`-gated (see below) |
 | `quality` | `[plan]` | `run-checks` | Lint / typecheck / security scan |
 | `test` | `[plan]` | `run-checks` | Unit + integration tests |
 | `build` | `[plan, quality, test]` | `run-build` | Compile binaries / wheels / packages, stamp version, upload `dist/` |
 | `release-tail` | `[plan, build]` | own gates | Container + tag-and-publish, via shared `_release-tail.yml` |
+
+`commit-check` is deliberately **independent of `plan` / `run-checks`**: that
+gate skips the quality job on ordinary (non-publish) merges to main, so a bad
+conventional-commit message could otherwise land unvalidated. It is a cheap
+git-log + regex check (no compile/publish), fatal on the push that actually
+reaches main and advisory on PRs (branch commits may be squashed away — only
+the squash subject lands). Feature-branch pushes skip it, preserving the
+chore-skip fast path. Logic: `hyperi_ci.quality.commit_validation.run`; the
+local `hyperi-ci check` runs the same validation over `origin/main..HEAD`.
 
 ### Gate outputs (computed in `plan`)
 
@@ -115,13 +125,14 @@ flowchart LR
 
 ### What runs when
 
-| Push type | plan | quality | test | build | container | tag+publish |
-|---|---|---|---|---|---|---|
-| `chore:` / `docs:` to main | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ |
-| `feat:`/`fix:` to main, no `Publish:` trailer | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ |
-| `feat:`/`fix:` to main + `Publish: true` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
-| Pull request | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ |
-| `workflow_dispatch` (retroactive publish) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Push type | plan | commit-check | quality | test | build | container | tag+publish |
+|---|---|---|---|---|---|---|---|
+| `chore:` / `docs:` to main | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ |
+| `feat:`/`fix:` to main, no `Publish:` trailer | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ |
+| `feat:`/`fix:` to main + `Publish: true` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Pull request | ✓ | ✓ advisory | ✓ | ✓ | ✗ | ✗ | ✗ |
+| `workflow_dispatch` (retroactive publish) | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| push to a feature branch | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 
 Tag-on-publish doctrine: a commit landing on main produces no tag and no
 artefacts. The operator opts in with `hyperi-ci push --publish` (adds the

--- a/src/hyperi_ci/cli.py
+++ b/src/hyperi_ci/cli.py
@@ -674,6 +674,23 @@ def check_commit_cmd(
     raise typer.Exit(1)
 
 
+@app.command(name="check-commits")
+def check_commits_cmd() -> None:
+    """Validate the conventional-commit messages in the CI push/PR range.
+
+    Landing-gate counterpart to `check-commit` (single message, local
+    commit-msg hook). Resolves the range from the CI event -- push
+    before..after (what lands on main) or PR base..HEAD -- validates each
+    commit, and is FATAL on push but ADVISORY on pull_request (branch
+    commits may be squashed away). CI-only; a no-op locally. Driven by the
+    dedicated `commit-check` workflow job, NOT the run-checks-gated quality
+    job -- so a merge to main is validated even when it is not a publish.
+    """
+    from hyperi_ci.quality.commit_validation import run
+
+    raise typer.Exit(run())
+
+
 def _publish_impl(
     tag: str | None,
     list_tags: bool,

--- a/src/hyperi_ci/dispatch.py
+++ b/src/hyperi_ci/dispatch.py
@@ -169,22 +169,30 @@ def stage_setup(language: str, config: CIConfig) -> int:
     return rc
 
 
-def stage_quality(language: str, config: CIConfig) -> int:
+def stage_quality(language: str, config: CIConfig, *, local: bool = False) -> int:
     """Quality checks — gitleaks + language-specific checks."""
     if not config.get("quality.enabled", True):
         info("Quality checks disabled in configuration")
         return 0
 
-    # Cross-language checks first
+    # Cross-language checks first.
     with group("Gitleaks secret scanning"):
         rc = gitleaks.run(config)
         if rc != 0:
             return rc
 
-    with group("Commit message validation"):
-        rc = commit_validation.run(config)
-        if rc != 0:
-            return rc
+    # Commit-message validation. In CI this is the dedicated `commit-check`
+    # workflow job -- it runs on every merge to main (not just the
+    # publish-worthy pushes the run-checks-gated quality job covers) and is
+    # advisory on PRs. There is no such job for a LOCAL `hyperi-ci check`,
+    # so run it here over the unpushed range (origin/main..HEAD) as a
+    # pre-push backstop -- catch a bad message before the push, not after.
+    # See hyperi_ci.quality.commit_validation.run + CLAUDE.md CI gate doctrine.
+    if local:
+        with group("Commit message validation"):
+            rc = commit_validation.run(config, local=True)
+            if rc != 0:
+                return rc
 
     extra_env: dict[str, str] = {}
     if language == "rust":
@@ -440,9 +448,11 @@ def run_stage(
         info(f"Project status: {status}{_STATUS_CLARIFIER.get(status, '')}")
 
     handler = _STAGE_HANDLERS[stage]
-    if stage == "build":
-        # The build handler takes `local`; the others do not. _STAGE_HANDLERS
-        # is typed to the common (no-local) signature, so cast for this branch.
+    if stage in ("build", "quality"):
+        # build + quality take `local` (build skips cross-targets; quality
+        # runs the commit-message backstop only for a local `hyperi-ci
+        # check`). _STAGE_HANDLERS is typed to the common (no-local)
+        # signature, so cast for this branch.
         rc = cast("Any", handler)(language, config, local=local)
     else:
         rc = handler(language, config)

--- a/src/hyperi_ci/quality/commit_validation.py
+++ b/src/hyperi_ci/quality/commit_validation.py
@@ -498,12 +498,35 @@ def _get_commits_to_validate() -> tuple[list[tuple[str, str]], bool]:
     return [], False
 
 
-def run(config: CIConfig, extra_env: dict[str, str] | None = None) -> int:
-    """Validate commit messages in the current branch.
+def run(
+    config: CIConfig | None = None,
+    extra_env: dict[str, str] | None = None,
+    *,
+    local: bool = False,
+) -> int:
+    """Validate commit messages in the CI push/PR range (or the local range).
 
-    Only runs inside CI (is_ci() guard). Returns 0 on success, 1 on failure.
+    ``config`` is unused (kept for call-site symmetry) so the CLI
+    ``check-commits`` command can call ``run()`` bare.
+
+    Behaviour by event:
+
+    - ``push`` (what lands on main) -> FATAL: a failing commit returns 1.
+      This is the real landing gate -- the run-checks gate skips the
+      quality job on non-publish main pushes, so this dedicated check is
+      where merge-to-main enforcement lives.
+    - ``pull_request`` -> ADVISORY: failures are warned, returns 0. The
+      branch commits validated on a PR may be discarded by a squash-merge
+      (only the squash subject lands) and are never re-validated on the
+      merge push, so a PR gets feedback rather than a hard red.
+
+    ``local=True`` runs the same check outside CI (``hyperi-ci check``
+    pre-push backstop): with no CI event the range falls back to
+    ``origin/main..HEAD`` (the unpushed commits) and is FATAL, so a bad
+    message is caught before the push, not after. Without ``local`` the
+    check is a no-op outside CI (the commit-msg hook covers authoring).
     """
-    if not is_ci():
+    if not local and not is_ci():
         info("Skipping commit message validation (not in CI)")
         return 0
 
@@ -543,10 +566,25 @@ def run(config: CIConfig, extra_env: dict[str, str] | None = None) -> int:
             failures.append((commit_hash, full_msg, result))
 
     if failures:
+        # Advisory on a PR, fatal on push. See the run() docstring: PR
+        # branch commits may be squashed away and are never re-validated
+        # on the merge-to-main push, so a PR gets feedback -- not a hard
+        # red -- while the push that lands on main stays enforced.
+        advisory = os.environ.get("GITHUB_EVENT_NAME", "") == "pull_request"
+        emit = warn if advisory else error
         for commit_hash, full_msg, result in failures:
             short_hash = commit_hash[:8]
             rejection = format_rejection(result, full_msg)
-            error(f"[{short_hash}] {rejection}")
+            emit(f"[{short_hash}] {rejection}")
+
+        if advisory:
+            warn(
+                f"{len(failures)} commit(s) would fail validation on merge to "
+                "main. Advisory on a PR -- only the commit(s) that LAND on main "
+                "are enforced. If you squash-merge, make the squash subject a "
+                "valid conventional commit (that single line is what lands)."
+            )
+            return 0
 
         error(
             f"{len(failures)} commit(s) failed validation. "

--- a/tests/unit/test_commit_validation.py
+++ b/tests/unit/test_commit_validation.py
@@ -679,6 +679,94 @@ class TestRunDegraded:
         assert rc == 0
 
 
+def _write_pr_event(tmp_path: Path, base_sha: str) -> Path:
+    payload = tmp_path / "event.json"
+    payload.write_text(json.dumps({"pull_request": {"base": {"sha": base_sha}}}))
+    return payload
+
+
+class TestRunAdvisoryOnPR:
+    """On a pull_request a failing commit is ADVISORY (warn, exit 0): branch
+    commits may be squashed away and are never re-validated on the merge-to-
+    main push. The push path stays FATAL (see TestRunDegraded)."""
+
+    def test_pr_failure_is_advisory(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        repo = _repo(tmp_path)
+        base = _commit(repo, "fix: base")
+        # GitHub branch-normalised squashy subject -> no valid prefix.
+        _git(repo, "commit", "--allow-empty", "-q", "-m", "Feat/bad squashy subject")
+        monkeypatch.chdir(repo)
+        monkeypatch.setenv("GITHUB_EVENT_NAME", "pull_request")
+        monkeypatch.setenv("GITHUB_EVENT_PATH", str(_write_pr_event(tmp_path, base)))
+        monkeypatch.setattr(cv, "is_ci", lambda: True)
+        warns: list[str] = []
+        errors: list[str] = []
+        monkeypatch.setattr(cv, "warn", lambda m: warns.append(m))
+        monkeypatch.setattr(cv, "error", lambda m: errors.append(m))
+
+        from hyperi_ci.config import CIConfig
+
+        rc = cv.run(CIConfig())
+        # Advisory: a bad commit must NOT hard-fail a PR...
+        assert rc == 0
+        # ...but the problem is still surfaced, via warn (not error).
+        assert any("would fail validation on merge to main" in w for w in warns)
+        assert errors == []
+
+    def test_pr_all_valid_passes(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        repo = _repo(tmp_path)
+        base = _commit(repo, "fix: base")
+        _commit(repo, "fix: good change")
+        monkeypatch.chdir(repo)
+        monkeypatch.setenv("GITHUB_EVENT_NAME", "pull_request")
+        monkeypatch.setenv("GITHUB_EVENT_PATH", str(_write_pr_event(tmp_path, base)))
+        monkeypatch.setattr(cv, "is_ci", lambda: True)
+
+        from hyperi_ci.config import CIConfig
+
+        rc = cv.run(CIConfig())
+        assert rc == 0
+
+
+class TestRunLocal:
+    """`local=True` (hyperi-ci check pre-push) validates the unpushed range
+    outside CI and is FATAL -- catch a bad message before the push. Without
+    it, run() is a no-op outside CI."""
+
+    def test_local_validates_range_and_is_fatal(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        repo = _repo(tmp_path)
+        # Simulate origin/main at the base, one unpushed bad commit on top.
+        _commit(repo, "fix: base")
+        _git(repo, "branch", "origin/main")  # local ref standing in for origin
+        _git(repo, "commit", "--allow-empty", "-q", "-m", "Broken No Prefix")
+        monkeypatch.chdir(repo)
+        monkeypatch.delenv("GITHUB_EVENT_NAME", raising=False)
+        monkeypatch.setattr(cv, "is_ci", lambda: False)
+        monkeypatch.setattr(cv, "warn", lambda _m: None)
+        monkeypatch.setattr(cv, "error", lambda _m: None)
+
+        rc = cv.run(local=True)
+        assert rc == 1  # not in CI, but local=True -> fatal on the bad commit
+
+    def test_not_local_and_not_ci_is_noop(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        repo = _repo(tmp_path)
+        _git(repo, "commit", "--allow-empty", "-q", "-m", "Broken No Prefix")
+        monkeypatch.chdir(repo)
+        monkeypatch.delenv("GITHUB_EVENT_NAME", raising=False)
+        monkeypatch.setattr(cv, "is_ci", lambda: False)
+
+        rc = cv.run()  # no local, not CI -> skip entirely
+        assert rc == 0
+
+
 def test_is_zero_sha() -> None:
     assert cv._is_zero_sha("0" * 40) is True
     assert cv._is_zero_sha("0" * 7) is True

--- a/tests/unit/test_workflow_consistency.py
+++ b/tests/unit/test_workflow_consistency.py
@@ -64,20 +64,19 @@ class TestFromHeadThreading:
         assert "bump" in wc, f"{workflow_name}: workflow_call missing bump"
 
     @pytest.mark.parametrize("workflow_name", LANGUAGE_WORKFLOWS)
-    def test_quality_deepens_history_for_commit_validation(
-        self, workflow_name: str
-    ) -> None:
-        # The quality checkout is depth-1; commit validation needs the pushed
-        # range before..after (issue #52). Every language workflow must deepen
-        # history immediately before running quality, or the CI-side
-        # conventional-commit backstop only sees HEAD (degraded).
+    def test_quality_deepens_history_for_secret_scan(self, workflow_name: str) -> None:
+        # The quality checkout is depth-1; gitleaks scans the branch git log
+        # for secrets and would only see HEAD without deepened history. Every
+        # language workflow must deepen immediately before running quality.
+        # (Conventional-commit validation moved to the commit-check job -- see
+        # TestCommitCheckJob.)
         wf = _load_workflow(workflow_name)
         steps = wf["jobs"]["quality"]["steps"]
         names = [s.get("name") for s in steps]
-        assert "Deepen history for commit validation" in names, (
-            f"{workflow_name}: quality job missing the history-deepen step (#52)"
+        assert "Deepen history for secret scan" in names, (
+            f"{workflow_name}: quality job missing the history-deepen step"
         )
-        i = names.index("Deepen history for commit validation")
+        i = names.index("Deepen history for secret scan")
         assert names[i + 1] == "Run quality checks", (
             f"{workflow_name}: deepen step must run immediately before quality"
         )
@@ -351,6 +350,57 @@ class TestReleaseTailDecoupling:
                 f"Docker step {s.get('name')!r} must gate on resolve output "
                 "so libraries skip Buildx/GHCR (issue #33)."
             )
+
+
+class TestCommitCheckJob:
+    """The commit-check job is the landing gate for conventional-commit
+    messages: it validates what actually reaches main (push) and gives
+    advisory feedback on PRs. Deliberately independent of the run-checks
+    gate so a merge to main is validated even when it is not publish-worthy
+    (that gate skips non-publish main pushes). See commit_validation.run +
+    CLAUDE.md CI gate doctrine.
+    """
+
+    @pytest.mark.parametrize("workflow_name", LANGUAGE_WORKFLOWS)
+    def test_commit_check_job_exists(self, workflow_name: str) -> None:
+        wf = _load_workflow(workflow_name)
+        assert "commit-check" in wf.get("jobs", {}), (
+            f"{workflow_name}: missing the commit-check landing-gate job"
+        )
+
+    @pytest.mark.parametrize("workflow_name", LANGUAGE_WORKFLOWS)
+    def test_commit_check_not_gated_on_run_checks(self, workflow_name: str) -> None:
+        # The whole point: it must NOT depend on plan.outputs.run-checks (that
+        # gate skips non-publish main pushes -- exactly where merge-to-main
+        # enforcement is needed). It gates on the event instead, and stays
+        # independent of plan so it runs in parallel.
+        wf = _load_workflow(workflow_name)
+        job = wf["jobs"]["commit-check"]
+        ifc = str(job.get("if", ""))
+        assert "run-checks" not in ifc, (
+            f"{workflow_name}: commit-check must NOT gate on run-checks"
+        )
+        assert "refs/heads/main" in ifc and "pull_request" in ifc, (
+            f"{workflow_name}: commit-check must run on push-to-main + PRs"
+        )
+        assert "needs" not in job, (
+            f"{workflow_name}: commit-check must be independent of plan"
+        )
+
+    @pytest.mark.parametrize("workflow_name", LANGUAGE_WORKFLOWS)
+    def test_commit_check_runs_check_commits(self, workflow_name: str) -> None:
+        wf = _load_workflow(workflow_name)
+        steps = wf["jobs"]["commit-check"]["steps"]
+        # Full history so before..after / base..HEAD resolves without a
+        # separate deepen step.
+        checkout = next(s for s in steps if "checkout" in str(s.get("uses", "")))
+        assert checkout.get("with", {}).get("fetch-depth") == 0, (
+            f"{workflow_name}: commit-check checkout must be fetch-depth: 0"
+        )
+        runs = " ".join(str(s.get("run", "")) for s in steps)
+        assert "check-commits" in runs, (
+            f"{workflow_name}: commit-check must invoke `hyperi-ci check-commits`"
+        )
 
 
 @pytest.mark.parametrize("workflow_name", LANGUAGE_WORKFLOWS)


### PR DESCRIPTION
## What

Moves conventional-commit validation out of the `run-checks`-gated `quality` job into a dedicated cheap `commit-check` job.

**Before:** validation only ran on PRs (against throwaway branch commits that a squash-merge discards) and on publish pushes. An ordinary squash-merge to main was **never** validated (`run-checks=false`), and UI-merge teams never hit the local `predicted_bump` guard (that only runs under `hyperi-ci push`). Net: no landing-time guard on main for GitHub-UI merges.

**After:** `commit-check` runs on push-to-main (**FATAL** - validates what actually lands) and on PRs (**ADVISORY** - branch commits may be squashed away, only the squash subject lands). It is a git-log + regex check, not `run-checks`-gated. Feature-branch pushes skip it, preserving the chore-skip fast path.

Local `hyperi-ci check` now runs the same validation over `origin/main..HEAD` (FATAL) so a bad message is caught in the local tight loop, not after the push - keeping `check` a complete local dry-run of what CI would flag.

## Where

- New `commit-check` job in all four reusable `<lang>-ci.yml` workflows + the self-hosting `ci.yml` (dogfoods on this PR).
- New `hyperi-ci check-commits` CLI entrypoint; `commit_validation.run` gains advisory-on-PR + `local=` modes.
- Removed from CI `stage_quality`; kept there only for local `check`.
- Docs: `docs/ARCHITECTURE.md` job-contract + what-runs-when tables.

## Notes

- The `feat:`/`BREAKING` opt-in gate is unchanged and still deliberate (comment-locked). This PR only changes *where/when* validation runs, not the rules.
- Merging rolls out to all consumers on `<lang>-ci.yml@main`. Advisory-on-PR means PRs won't newly break; push-to-main will now flag a genuinely bad squash subject landing on main (branch protection is off, so it signals rather than blocks).
- Surfaced by dfe-ui#81.