### PR TITLE
fix: plan job needs contents write for publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,9 +48,10 @@ concurrency:
   cancel-in-progress: true
 
 # Least-privilege GITHUB_TOKEN default for every job (CodeQL
-# actions/missing-workflow-permissions). Only release-tail elevates -- it
-# passes write down to _release-tail.yml (semantic-release commit/tag + GHCR).
-# plan / commit-check / quality / test / build are read-only.
+# actions/missing-workflow-permissions). Two jobs elevate: release-tail
+# (passes write down to _release-tail.yml -- semantic-release commit/tag +
+# GHCR) and plan (semantic-release push-access verify on a publish predict).
+# commit-check / quality / test / build are read-only.
 permissions:
   contents: read
 
@@ -59,6 +60,10 @@ jobs:
     name: Plan
     if: github.event.pull_request.head.repo.fork != true
     runs-on: ubuntu-latest
+    # predict-version runs semantic-release, whose git plugin verifies push
+    # access (a `git push --dry-run`) on a publish predict -- needs write.
+    permissions:
+      contents: write
     outputs:
       run-checks: ${{ steps.predict.outputs.run-checks }}
       run-build: ${{ steps.predict.outputs.run-build }}

--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -112,9 +112,10 @@ env:
   HYPERCI_QUALITY_SKIP: ${{ vars.HYPERCI_QUALITY_SKIP }}
 
 # Least-privilege GITHUB_TOKEN default for every job (CodeQL
-# actions/missing-workflow-permissions). Only release-tail elevates -- it
-# passes write down to _release-tail.yml (semantic-release commit/tag + GHCR).
-# plan / commit-check / quality / test / build are read-only.
+# actions/missing-workflow-permissions). Two jobs elevate: release-tail
+# (passes write down to _release-tail.yml -- semantic-release commit/tag +
+# GHCR) and plan (semantic-release push-access verify on a publish predict).
+# commit-check / quality / test / build are read-only.
 permissions:
   contents: read
 
@@ -127,6 +128,10 @@ jobs:
     name: Plan
     if: github.event.pull_request.head.repo.fork != true
     runs-on: ubuntu-latest
+    # predict-version runs semantic-release, whose git plugin verifies push
+    # access (a `git push --dry-run`) on a publish predict -- needs write.
+    permissions:
+      contents: write
     outputs:
       run-checks: ${{ steps.predict.outputs.run-checks }}
       run-build: ${{ steps.predict.outputs.run-build }}

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -116,9 +116,10 @@ env:
   HYPERCI_QUALITY_SKIP: ${{ vars.HYPERCI_QUALITY_SKIP }}
 
 # Least-privilege GITHUB_TOKEN default for every job (CodeQL
-# actions/missing-workflow-permissions). Only release-tail elevates -- it
-# passes write down to _release-tail.yml (semantic-release commit/tag + GHCR).
-# plan / commit-check / quality / test / build are read-only.
+# actions/missing-workflow-permissions). Two jobs elevate: release-tail
+# (passes write down to _release-tail.yml -- semantic-release commit/tag +
+# GHCR) and plan (semantic-release push-access verify on a publish predict).
+# commit-check / quality / test / build are read-only.
 permissions:
   contents: read
 
@@ -132,6 +133,10 @@ jobs:
     name: Plan
     if: github.event.pull_request.head.repo.fork != true
     runs-on: ubuntu-latest
+    # predict-version runs semantic-release, whose git plugin verifies push
+    # access (a `git push --dry-run`) on a publish predict -- needs write.
+    permissions:
+      contents: write
     outputs:
       run-checks: ${{ steps.predict.outputs.run-checks }}
       run-build: ${{ steps.predict.outputs.run-build }}

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -124,9 +124,10 @@ env:
   HYPERCI_QUALITY_SKIP: ${{ vars.HYPERCI_QUALITY_SKIP }}
 
 # Least-privilege GITHUB_TOKEN default for every job (CodeQL
-# actions/missing-workflow-permissions). Only release-tail elevates -- it
-# passes write down to _release-tail.yml (semantic-release commit/tag + GHCR).
-# plan / commit-check / quality / test / build are read-only.
+# actions/missing-workflow-permissions). Two jobs elevate: release-tail
+# (passes write down to _release-tail.yml -- semantic-release commit/tag +
+# GHCR) and plan (semantic-release push-access verify on a publish predict).
+# commit-check / quality / test / build are read-only.
 permissions:
   contents: read
 
@@ -147,6 +148,10 @@ jobs:
     name: Plan
     if: github.event.pull_request.head.repo.fork != true
     runs-on: ubuntu-latest
+    # predict-version runs semantic-release, whose git plugin verifies push
+    # access (a `git push --dry-run`) on a publish predict -- needs write.
+    permissions:
+      contents: write
     outputs:
       run-checks: ${{ steps.predict.outputs.run-checks }}
       run-build: ${{ steps.predict.outputs.run-build }}

--- a/.github/workflows/ts-ci.yml
+++ b/.github/workflows/ts-ci.yml
@@ -114,9 +114,10 @@ env:
   HYPERCI_QUALITY_SKIP: ${{ vars.HYPERCI_QUALITY_SKIP }}
 
 # Least-privilege GITHUB_TOKEN default for every job (CodeQL
-# actions/missing-workflow-permissions). Only release-tail elevates -- it
-# passes write down to _release-tail.yml (semantic-release commit/tag + GHCR).
-# plan / commit-check / quality / test / build are read-only.
+# actions/missing-workflow-permissions). Two jobs elevate: release-tail
+# (passes write down to _release-tail.yml -- semantic-release commit/tag +
+# GHCR) and plan (semantic-release push-access verify on a publish predict).
+# commit-check / quality / test / build are read-only.
 permissions:
   contents: read
 
@@ -129,6 +130,10 @@ jobs:
     name: Plan
     if: github.event.pull_request.head.repo.fork != true
     runs-on: ubuntu-latest
+    # predict-version runs semantic-release, whose git plugin verifies push
+    # access (a `git push --dry-run`) on a publish predict -- needs write.
+    permissions:
+      contents: write
     outputs:
       run-checks: ${{ steps.predict.outputs.run-checks }}
       run-build: ${{ steps.predict.outputs.run-build }}


### PR DESCRIPTION
PR #59's least-privilege sweep set the workflow-level GITHUB_TOKEN default to contents: read with no override on the plan job. plan runs the predict-version composite, whose semantic-release git plugin verifies push access (a git push --dry-run) on a publish predict -> 403 EGITNOPERMISSION. Every publish on @main is broken - hyperi-ci's own and every consumer's next release. Validate-only runs never push-verify, which is why PR CI and both review passes missed it.

Fix: restore contents: write on the plan job in all 5 workflows (ci, rust-ci, python-ci, go-ci, ts-ci) and correct the workflow-level comment. commit-check / quality / test / build stay read-only.

Verified: workflow consistency + interface tests green, full check (1165 tests) green.