### PR TITLE
fix: purge deprecated hyperi-pylib references

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -244,26 +244,11 @@ jobs:
     strategy:
       matrix:
         os: ${{ fromJson(startsWith(github.head_ref || github.ref_name, 'renovate/') && format('["{0}"]', vars.GH_RUNNER_RENOVATE || 'ubuntu-latest') || (inputs.runner-mode || vars.GH_RUNNER_MODE) == 'free' && '["ubuntu-latest"]' || inputs.test-matrix || format('["{0}"]', inputs.runner-test || vars.GH_RUNNER_PYTHON || vars.GH_RUNNER_DEFAULT || 'ubuntu-latest')) }}
-    # Service containers required by integration tests.
-    # Always-on: harmless overhead for consumers that don't use them
-    # (job runs `psql` etc. against localhost ports). pylib's
-    # tests/conftest.py postgres fixture finds these via the
-    # `postgresql://postgres:postgres@localhost:5432/hyperi_pylib_test`
-    # DSN; matches pylib's docker-compose.postgres.yml.
-    services:
-      postgres:
-        image: postgres:18-alpine
-        env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: hyperi_pylib_test
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd "pg_isready -U postgres -d hyperi_pylib_test"
-          --health-interval 5s
-          --health-timeout 5s
-          --health-retries 10
+    # Service containers for consumer integration tests would go here
+    # (always-on is harmless overhead for consumers that don't use
+    # them). The postgres service that used to live here served only
+    # the deprecated scalo predecessor's test suite; scalo has no
+    # live postgres fixture, so the block was removed.
     steps:
       - name: Docker Hub login
         if: ${{ vars.DOCKERHUB_USERNAME != '' }}
@@ -374,7 +359,7 @@ jobs:
         run: ${{ env.HYPERCI_INSTALL }} run build
 
       - name: Generate deployment artefacts
-        # Pylib's Application.deployment_contract() emits Dockerfile.runtime +
+        # scalo's Application.deployment_contract() emits Dockerfile.runtime +
         # container-manifest.json (+ ArgoCD) into ci-tmp/. Skipped silently
         # for projects without a deployment contract.
         run: ${{ env.HYPERCI_INSTALL }} run generate

--- a/README.md
+++ b/README.md
@@ -363,7 +363,7 @@ Three-tier producer model (auto-detected):
 | Tier | Detected by | Producer |
 |---|---|---|
 | **Tier 1** (`rust`) | Cargo.toml + `scalo` dep | `<app> generate-artefacts` (scalo) |
-| **Tier 2** (`python`) | pyproject.toml + `scalo` dep (or legacy `hyperi-pylib`) | `<app> generate-artefacts` (scalo) |
+| **Tier 2** (`python`) | pyproject.toml + `scalo` dep | `<app> generate-artefacts` (scalo) |
 | **Tier 3** (`other`) | `ci/deployment-contract.json` only | `hyperi-ci emit-artefacts` |
 | (none) | nothing | container stage no-ops silently |
 

--- a/docs/JFROG-MIGRATION.md
+++ b/docs/JFROG-MIGRATION.md
@@ -88,7 +88,7 @@ flowchart TB
 | `hyperi-docker-local` | 6.6 GB | ci-runner + dfe-loader container | **Migrate to GHCR** |
 | `hyperi-binaries` | 2.0 GB | dfe-loader binary artifacts | **Delete (already on R2 + GH Releases)** |
 | `hypersec-terraform` | 1.3 GB | Terraform state backend | **Keep (or move to S3 later)** |
-| `hyperi-pypi-local` | 0.4 GB | dfe-engine, hyperi-pylib, dfecli | **Keep (private staging)** |
+| `hyperi-pypi-local` | 0.4 GB | dfe-engine, scalo, dfecli | **Keep (private staging)** |
 | `hyperi-cargo-local` | 29.6 MB | Private Rust crates | **Keep (private staging)** |
 | `hyperi-npm-local` | 0.9 MB | npm packages | **Migrate to GH Packages npm** |
 | `hyperi-helm-local` | 12 files | Helm charts | **Migrate to GHCR OCI** |

--- a/docs/README.md
+++ b/docs/README.md
@@ -132,8 +132,7 @@ Solid arrows are run-order / data flow. Dashed arrows are "calls / uses".
 
 - **Package:** [hyperi-ci](https://pypi.org/project/hyperi-ci/) (PyPI)
 - **Runtime dep:** [scalo](https://pypi.org/project/scalo/)
-  (successor to the deprecated hyperi-pylib; a broken scalo would break
-  CI for every repo)
+  (a broken scalo would break CI for every repo)
 - **Languages:** Rust, Python, TypeScript, Go
 - **Self-hosting:** hyperi-ci runs its own CI through its own reusable workflow
 - **Used by:** dfe-engine, dfe-receiver, dfe-loader, dfe-archiver, dfe-fetcher,

--- a/docs/dependencies/DEPS-PINNING.md
+++ b/docs/dependencies/DEPS-PINNING.md
@@ -18,7 +18,7 @@ For our *own* reusable-workflow internals (which stay `@main` on purpose), see
 **Why the caller is exempt.** SHA-pinning protects against *third-party*
 supply-chain risk. The hyperi-ci reusable workflow is our *own* CI tool —
 pinning its version at the consumer just freezes consumers off CI fixes
-(it stuck hyperi-pylib on v2.6.1, dfe-receiver on v2.6.4). Consumers call
+(it stuck scalo-py on v2.6.1, dfe-receiver on v2.6.4). Consumers call
 `<lang>-ci.yml@main` and always get latest; safety for `@main` is hyperi-ci's
 internal interface gate (see [WORKFLOW-PINNING.md](WORKFLOW-PINNING.md), issue
 #31), not a consumer pin. A deliberate pin (`@vN`, or `@sha` for a known

--- a/docs/dependencies/WORKFLOW-PINNING.md
+++ b/docs/dependencies/WORKFLOW-PINNING.md
@@ -14,7 +14,7 @@ The language reusable workflows (`rust-ci.yml`, `python-ci.yml`, …) call their
 sibling composites + `_release-tail.yml` at `@main`. A consumer SHA-pins the
 *caller* (via Renovate), but those internals resolve **live from `main`** at run
 time. So a breaking interface change on `main` **retroactively breaks every
-pinned consumer** at startup — 0 jobs, no logs. It bit hyperi-pylib once. The
+pinned consumer** at startup — 0 jobs, no logs. It bit scalo-py once. The
 pin is skin-deep: the *cost* of pinning without the *benefit*.
 
 ```mermaid
@@ -142,7 +142,7 @@ push-branch → open PR → self-merge.
 Originally the consumer *caller* was SHA-pinned (by Renovate) while the
 internals floated `@main` — the worst of both: a pinned caller that still broke
 when `main` regressed, **and** consumers frozen off CI fixes (it stuck
-hyperi-pylib on v2.6.1, dfe-receiver on v2.6.4). Since the gate already makes
+scalo-py on v2.6.1, dfe-receiver on v2.6.4). Since the gate already makes
 `@main` safe, the caller is now `@main` too: `init` scaffolds
 `<lang>-ci.yml@main`, and the org Renovate preset **carves the hyperi-ci caller
 out of digest pinning** so it is never re-pinned (see

--- a/docs/migration/JFROG.md
+++ b/docs/migration/JFROG.md
@@ -88,7 +88,7 @@ flowchart TB
 | `hyperi-docker-local` | 6.6 GB | ci-runner + dfe-loader container | **Migrate to GHCR** |
 | `hyperi-binaries` | 2.0 GB | dfe-loader binary artifacts | **Delete (already on R2 + GH Releases)** |
 | `hypersec-terraform` | 1.3 GB | Terraform state backend | **Keep (or move to S3 later)** |
-| `hyperi-pypi-local` | 0.4 GB | dfe-engine, hyperi-pylib, dfecli | **Keep (private staging)** |
+| `hyperi-pypi-local` | 0.4 GB | dfe-engine, scalo, dfecli | **Keep (private staging)** |
 | `hyperi-cargo-local` | 29.6 MB | Private Rust crates | **Keep (private staging)** |
 | `hyperi-npm-local` | 0.9 MB | npm packages | **Migrate to GH Packages npm** |
 | `hyperi-helm-local` | 12 files | Helm charts | **Migrate to GHCR OCI** |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,10 +38,9 @@ dependencies = [
     # Pin to >= so transitive resolution can pick up bug fixes / new
     # features without a manifest edit. Bump the floor when we adopt
     # new scalo APIs (e.g. deployment contract module added in 2.28).
-    # scalo is the successor to the deprecated hyperi-pylib (same
-    # version lineage). The [metrics] extra is required because
-    # scalo's __init__.py eagerly imports scalo.metrics -> psutil.
-    # Architectural fix (lazy metrics import) is tracked in scalo.
+    # The [metrics] extra is required because scalo's __init__.py
+    # eagerly imports scalo.metrics -> psutil. Architectural fix
+    # (lazy metrics import) is tracked in scalo.
     "scalo[metrics]>=2.28.5",
     "oras>=0.2.42",
     "packaging>=26.0",

--- a/src/hyperi_ci/deployment/detect.py
+++ b/src/hyperi_ci/deployment/detect.py
@@ -12,9 +12,8 @@ right producer:
   Tier 1 (RUST)   — Cargo.toml depends on scalo (or legacy
                     hyperi-rustlib); the binary itself emits artefacts
                     via `<app> generate-artefacts`.
-  Tier 2 (PYTHON) — pyproject.toml depends on scalo (or legacy
-                    hyperi-pylib); the entry point emits via
-                    `<app> generate-artefacts`.
+  Tier 2 (PYTHON) — pyproject.toml depends on scalo; the entry point
+                    emits via `<app> generate-artefacts`.
   Tier 3 (OTHER)  — repo commits ``ci/deployment-contract.json``;
                     hyperi-ci's own templater emits.
   NONE            — no contract at all; container stage skips silently.
@@ -45,12 +44,13 @@ class Tier(StrEnum):
 
 # Marker deps, in match precedence. ``scalo`` is the current lib name
 # on BOTH sides (the crate scalo-rs on crates.io, and the scalo package
-# on PyPI); the ``hyperi-*lib`` names are the deprecated predecessors,
-# kept so consumer repos mid-migration still detect. No ambiguity from
-# the shared ``scalo`` name: Tier 1 only reads Cargo.toml, Tier 2 only
-# reads pyproject.toml.
+# on PyPI); ``hyperi-rustlib`` is the deprecated Rust predecessor, kept
+# so consumer repos mid-migration still detect. The deprecated Python
+# predecessor has no active consumers left, so it is not detected. No
+# ambiguity from the shared ``scalo`` name: Tier 1 only reads
+# Cargo.toml, Tier 2 only reads pyproject.toml.
 _RUST_DEPLOYMENT_DEPS: tuple[str, ...] = ("scalo", "hyperi-rustlib")
-_PYTHON_DEPLOYMENT_DEPS: tuple[str, ...] = ("scalo", "hyperi-pylib")
+_PYTHON_DEPLOYMENT_DEPS: tuple[str, ...] = ("scalo",)
 
 
 def detect_tier(repo_root: Path) -> Tier:
@@ -59,8 +59,7 @@ def detect_tier(repo_root: Path) -> Tier:
     Order of precedence:
       1. Cargo.toml + scalo (or legacy hyperi-rustlib) in deps
          → :attr:`Tier.RUST`
-      2. pyproject.toml + scalo (or legacy hyperi-pylib) in deps
-         → :attr:`Tier.PYTHON`
+      2. pyproject.toml + scalo in deps → :attr:`Tier.PYTHON`
       3. ``ci/deployment-contract.json`` exists → :attr:`Tier.OTHER`
       4. Otherwise → :attr:`Tier.NONE`
 
@@ -118,7 +117,7 @@ def _depends_on(manifest: Path, package_name: str) -> bool:
     repo gets misdispatched as a Tier 1/2 consumer and the
     deployment-artefact producer fails with "no Rust binary found" /
     equivalent. The check is generic — applies to any marker dep
-    (scalo, the legacy hyperi-*lib names, future *lib) and to consumer
+    (scalo, the legacy hyperi-rustlib, future libs) and to consumer
     projects whose own name happens to share a prefix (scalo's own
     repo, for one).
 

--- a/tests/unit/deployment/test_detect_tier.py
+++ b/tests/unit/deployment/test_detect_tier.py
@@ -75,22 +75,6 @@ class TestDetectTier:
         )
         assert detect_tier(tmp_path) == Tier.PYTHON
 
-    def test_pyproject_with_legacy_pylib_is_python(self, tmp_path: Path) -> None:
-        # hyperi-pylib is deprecated but still recognised for consumers
-        # mid-migration to scalo.
-        (tmp_path / "pyproject.toml").write_text(
-            '[project]\nname = "x"\ndependencies = ["hyperi-pylib>=2.24"]\n',
-            encoding="utf-8",
-        )
-        assert detect_tier(tmp_path) == Tier.PYTHON
-
-    def test_pyproject_with_legacy_pylib_extras_is_python(self, tmp_path: Path) -> None:
-        (tmp_path / "pyproject.toml").write_text(
-            '[project]\nname = "x"\ndependencies = ["hyperi-pylib[metrics]>=2.24"]\n',
-            encoding="utf-8",
-        )
-        assert detect_tier(tmp_path) == Tier.PYTHON
-
     def test_pyproject_without_scalo_is_not_python(self, tmp_path: Path) -> None:
         (tmp_path / "pyproject.toml").write_text(
             '[project]\nname = "x"\ndependencies = ["pyyaml>=6"]\n',
@@ -187,13 +171,6 @@ class TestSelfMatchExclusion:
     def test_scalo_own_repo_is_not_python(self, tmp_path: Path) -> None:
         (tmp_path / "pyproject.toml").write_text(
             '[project]\nname = "scalo"\nversion = "2.29.0"\n',
-            encoding="utf-8",
-        )
-        assert detect_tier(tmp_path) == Tier.NONE
-
-    def test_legacy_pylib_own_repo_is_not_python(self, tmp_path: Path) -> None:
-        (tmp_path / "pyproject.toml").write_text(
-            '[project]\nname = "hyperi-pylib"\nversion = "2.24.0"\n',
             encoding="utf-8",
         )
         assert detect_tier(tmp_path) == Tier.NONE


### PR DESCRIPTION
Purge hyperi-pylib references - scalo is the successor and already the dep.
Tier-2 detection matches scalo only; pylib branches and test fixtures removed.
python-ci.yml drops the postgres service that served only pylib's own tests.
docs/superpowers/{plans,specs} left verbatim (historical records).
