### PR TITLE
feat: add container + k8s + IaC linting dimension

### DIFF
--- a/config/versions.yaml
+++ b/config/versions.yaml
@@ -94,6 +94,18 @@ tools:
     version: v8.30.1
     repo: gitleaks/gitleaks
     pin: src/hyperi_ci/quality/gitleaks.py
+  hadolint:
+    version: v2.14.0
+    repo: hadolint/hadolint
+    pin: src/hyperi_ci/quality/hadolint.py
+  kubeconform:
+    version: v0.8.0
+    repo: yannh/kubeconform
+    pin: src/hyperi_ci/quality/kubeconform.py
+  kube-linter:
+    version: v0.8.3
+    repo: stackrox/kube-linter
+    pin: src/hyperi_ci/quality/kube_linter.py
   osv-scanner:
     version: v2.4.0
     repo: google/osv-scanner

--- a/docs/migration/onboarding.md
+++ b/docs/migration/onboarding.md
@@ -1,5 +1,20 @@
 # Migration Guide
 
+## Container + k8s + IaC linting added
+
+The quality stage now runs hadolint as a **blocking Dockerfile gate** (plus the
+droast advisory), and a new `hyperi-ci lint-manifests` verb covers gitops / infra
+repos (kubeconform gate + kube-linter/checkov advisories). Full reference:
+[quality-gate.md](../quality-gate.md).
+
+**Behaviour change before you bump:** a repo that HAS a Dockerfile with an
+**error-severity** hadolint finding (chiefly a broken `RUN` shell caught by
+ShellCheck) will newly FAIL CI. Routine noise (DL3008 unpinned apt, DL4006
+pipefail) stays warning-tier and never fails; a repo with no Dockerfile sees no
+change, and the k8s/IaC tools only run when you explicitly call `lint-manifests`.
+On first adoption run `hyperi-ci run quality` locally, or set `quality.hadolint:
+warn` for a migration window, then flip back to `blocking` once clean.
+
 ## v2.1.4 - JFrog removed
 
 JFrog publishing was removed entirely in v2.1.4. Every artefact now

--- a/docs/quality-gate.md
+++ b/docs/quality-gate.md
@@ -62,6 +62,11 @@ Set per project in `.hyperi-ci.yaml` under `quality.<lang>.<tool>` (or
 |---|---|---|
 | gitleaks | cross-language secret scan | dispatch (`quality/gitleaks.py`) |
 | semgrep | cross-language SAST (`--config auto`) | dispatch (`quality/semgrep.py`) |
+| hadolint | Dockerfile lint GATE (shellcheck-on-`RUN`) | dispatch (`quality/hadolint.py`) |
+| droast | Dockerfile ADVISORY (cache / dockerignore) | dispatch (`quality/droast.py`) |
+| kubeconform | k8s manifest schema GATE | `lint-manifests` verb (`quality/kubeconform.py`) |
+| kube-linter | k8s best-practice ADVISORY | `lint-manifests` verb (`quality/kube_linter.py`) |
+| checkov | IaC security ADVISORY (k8s/helm/tf) | `lint-manifests` verb (`quality/checkov.py`) |
 | ruff (lint, format, docstrings) | Python | `languages/python/quality.py` |
 | ty | Python types | Python handler |
 | pip-audit, bandit, vulture | Python | Python handler |
@@ -108,6 +113,138 @@ config is sane.
 repo config passed via `--config` beats them, but with no repo config they take
 over silently - so hyperi-ci warns when one is set and there is nothing to
 override it. Prefer a committed `.gitleaks.toml`: it gets reviewed.
+
+## Container + k8s + IaC linting
+
+Five tools cover three artefact classes, each with a **gate** (blocks) and an
+**advisory** (warns, never blocks):
+
+| Layer | Dockerfiles | k8s manifests | IaC |
+|---|---|---|---|
+| Gate (blocking) | hadolint | kubeconform | - |
+| Advisory (warn) | droast | kube-linter | checkov (k8s/helm/kustomize/terraform) |
+
+They deliver through two paths, because the target repos differ in kind:
+
+- **Path A - the quality stage.** hadolint + droast auto-detect Dockerfiles
+  inside `hyperi-ci run quality`, like gitleaks/semgrep. A repo with no
+  Dockerfile just info-skips - no opt-out config needed.
+- **Path B - the `lint-manifests` verb.** `hyperi-ci lint-manifests <dir>` runs
+  kubeconform + kube-linter + checkov. Built for GitHub-Actions-native gitops /
+  infra repos that have no `.hyperi-ci.yaml` and no language pipeline - the
+  existing workflow calls the verb instead of adopting the whole pipeline. It
+  renders Helm charts (`helm template`) for kubeconform, which validates
+  RENDERED manifests.
+
+### Gate semantics
+
+hadolint gates on **error severity only**: a blocking hadolint fails on an
+error-level finding (a broken `RUN` shell caught by ShellCheck), while
+warning/info (DL3008 apt-pin, DL4006 pipefail, ...) surface but never fail.
+kubeconform fails on a schema-invalid manifest. droast, kube-linter and checkov
+are advisory by default and never fail the build (checkov can be escalated to
+`blocking` per repo once its findings are tuned).
+
+### How findings surface (the layered stack)
+
+Every tool parses its output into one shared surface (`quality/findings.py`):
+
+- **GitHub annotations** - a *bounded* set of inline pointers, errors first.
+  GitHub caps annotations at 10 error + 10 warning per step and silently drops
+  the rest; the whole quality stage is one step, so that budget is shared across
+  all tools. When it is exhausted the log says "+N more, see summary".
+- **Job summary** - the *complete* findings list as a markdown table
+  (`$GITHUB_STEP_SUMMARY`), bounded at 1000 rows (well past any real run) with a
+  truncation note, so it stays under GitHub's 1MiB/step ceiling. The
+  authoritative record.
+- **SARIF** - opt-in via `--sarif <path>` on the verb. Writing the file is
+  always safe; UPLOADING it into code scanning needs GitHub Code Security (a
+  paid add-on on private repos), so the *workflow* does the upload, gated to
+  where it is enabled - hyperi-ci never uploads and never triggers the "must
+  enable" error.
+
+### Config
+
+Modes are the usual `blocking` / `warn` / `disabled` under `quality.<tool>`
+(cross-language, top-level - not per-language). `quality.<tool>` may also be a
+**dict** carrying a `mode` plus tool options:
+
+```yaml
+quality:
+  hadolint: blocking          # or warn / disabled
+  droast: warn
+  kubeconform:
+    mode: blocking
+    schema_locations:         # extra CRD schema locations for kubeconform
+      - /path/to/crd-schemas
+  checkov:
+    mode: warn
+    frameworks: [kubernetes, helm, terraform]
+    skip: [CKV_K8S_35]        # skip check IDs (e.g. an ExternalSecret false positive)
+    skip_paths: ['.*/vendor/.*']  # extra path regexes to exclude (on top of .worktrees / .tmp)
+```
+
+### Coverage caveats (a green gate is not full proof)
+
+- kubeconform runs with `-ignore-missing-schemas`: a CRD with no schema anywhere
+  is **skipped**, not validated. A curated CRD schema location (the datreeio
+  catalogue is included by default) covers the common operators; the rest are
+  reported skipped, not green-lit.
+- For multi-source ArgoCD apps, the rendered manifest uses **in-repo default
+  values only** - the real cluster manifest depends on an external overlay, so a
+  passing kubeconform gate validates the chart-under-defaults, not the deployed
+  result.
+
+### Does this break existing projects?
+
+No, by design - the failure surface is deliberately narrow:
+
+- **No Dockerfile, no k8s, no `.tf` -> nothing runs.** hadolint/droast auto-detect
+  Dockerfiles and info-skip a repo with none. The k8s/IaC tools only run when you
+  explicitly call `lint-manifests`. A plain Rust/Python library sees zero change.
+- **The k8s/IaC tools never run in the normal quality stage.** kubeconform,
+  kube-linter and checkov are *only* reachable through the `lint-manifests` verb
+  (Path B). Bumping hyperi-ci does not add them to any language project's CI - a
+  gitops repo has to opt in by calling the verb.
+- **The one gate that auto-runs (hadolint) fails on ERROR severity only.** Routine
+  Dockerfile noise (DL3008 unpinned apt, DL4006 pipefail, base-image pinning) is
+  warning-tier and is surfaced, not failed. Only a genuine defect - chiefly a
+  broken `RUN` shell caught by embedded ShellCheck - fails the build.
+- **A missing tool never breaks the local loop.** `hyperi-ci check` warn-skips a
+  linter that is not installed; in CI hadolint auto-installs, and if that install
+  itself fails the stage does not crash (it reports and, for a blocking gate,
+  fails rather than falsely pass).
+- **Everything is opt-out** per repo: `quality.hadolint: disabled` (or `warn`),
+  and the same for each tool.
+
+**The one real behaviour change:** a project that *has* a Dockerfile whose hadolint
+finds an **error-severity** issue will newly fail CI where it previously had no
+Dockerfile check at all. That is the intended gate (a broken `RUN` is a real bug),
+but it is a change - so on first adoption, run `hyperi-ci run quality` locally, or
+set `quality.hadolint: warn` for a migration window, fix the findings, then flip it
+back to `blocking`.
+
+### Adopting it on a new or external project
+
+- **A language project (Python/Rust/Go/TS) that already uses hyperi-ci** - nothing
+  to do. hadolint + droast light up automatically the next time `run quality`
+  executes, *iff* the repo has a Dockerfile. Tune with `quality.hadolint` /
+  `quality.droast` if needed.
+- **A brand-new project** - onboard it with `hyperi-ci init` / `/onboard` as usual;
+  the linting is part of the quality stage it scaffolds. No extra wiring.
+- **A gitops / infra repo (Helm charts, k8s manifests, `.tf`)** - even one that is
+  GitHub-Actions-native with no `.hyperi-ci.yaml` - add one step to its workflow:
+  `hyperi-ci lint-manifests .`. It needs `helm` on the runner for the kubeconform
+  schema gate (kube-linter/checkov still run without it). A CRD-heavy cluster repo
+  will want `quality.kubeconform.schema_locations` for its operators and a
+  `quality.checkov.skip` list for known false positives (e.g. External-Secrets
+  `ExternalSecret` CRs). The gitops scaffold (`hyperi-ci init-gitops`) ships a
+  `validate.yaml` that already calls the verb.
+- **An external / third-party project you are migrating in** - start every tool at
+  `warn` (advisory) so the first run is a report, not a wall of failures; triage
+  the findings; then promote hadolint (and, if wanted, checkov) to `blocking` once
+  the repo is clean. The auto-detect + opt-out model means adoption is incremental,
+  never all-or-nothing.
 
 ## --strict - a zero-warnings pre-push gate
 

--- a/src/hyperi_ci/cli.py
+++ b/src/hyperi_ci/cli.py
@@ -158,6 +158,42 @@ def check(
     raise typer.Exit(0)
 
 
+@app.command(name="lint-manifests")
+def lint_manifests_cmd(
+    directory: Annotated[
+        str,
+        typer.Argument(help="Directory to lint (Helm charts / k8s manifests / IaC)"),
+    ] = ".",
+    sarif: Annotated[
+        str | None,
+        typer.Option(
+            "--sarif",
+            help=(
+                "Write combined SARIF here (opt-in). The workflow uploads it to "
+                "code scanning only where GitHub Code Security is enabled."
+            ),
+        ),
+    ] = None,
+) -> None:
+    """Lint Kubernetes manifests, Helm charts and IaC in a gitops / infra repo.
+
+    Runs kubeconform (schema-validation GATE), kube-linter (best-practice
+    ADVISORY) and Checkov (IaC security ADVISORY). Only kubeconform gates: a
+    schema-invalid manifest exits non-zero; the advisories never fail the build.
+
+    Built for GitHub-Actions-native gitops repos (no ``.hyperi-ci.yaml``, no
+    language pipeline) - call it from the existing workflow instead of adopting
+    the whole hyperi-ci pipeline.
+    """
+    from hyperi_ci.config import load_config
+    from hyperi_ci.quality import lint_manifests
+
+    root = Path(directory)
+    config = load_config(project_dir=root)
+    rc = lint_manifests.run(root, config, sarif_path=sarif)
+    raise typer.Exit(rc)
+
+
 @app.command()
 def push(
     publish: Annotated[
@@ -1215,7 +1251,7 @@ def init_gitops_cmd(
     """Scaffold a new hyperi-io/gitops monorepo from bundled templates.
 
     Creates the standard directory structure, GitHub Actions workflows,
-    ArgoCD manifests, Terraform skeleton, and MkDocs documentation site
+    ArgoCD manifests, OpenTofu skeleton, and MkDocs documentation site
     in TARGET.
 
     Example:

--- a/src/hyperi_ci/config/defaults.yaml
+++ b/src/hyperi_ci/config/defaults.yaml
@@ -70,6 +70,18 @@ quality:
   exclude_paths: []
   gitleaks: blocking
   semgrep: warn              # Semgrep SAST (cross-language) - runs once at dispatch, like gitleaks
+
+  # Container linting (cross-language, dispatch-level, auto-detect Dockerfiles).
+  hadolint: blocking         # Dockerfile GATE - blocks on ERROR severity only (shellcheck-on-RUN)
+  droast: warn               # Dockerfile ADVISORY - cache order / .dockerignore / npm ci; never gates
+
+  # k8s + IaC linting (Path B - `hyperi-ci lint-manifests`, gitops/infra repos).
+  # Also honoured if a language project ships charts/manifests. May be a mode
+  # string OR a dict with `mode` + tool options (see docs/quality-gate.md).
+  kubeconform: blocking      # k8s schema-validation GATE (rendered manifests)
+  kube_linter: warn          # k8s best-practice ADVISORY; never gates
+  checkov: warn              # IaC security ADVISORY (k8s/helm/kustomize/terraform); never gates by default
+
   alint: auto                # Repo-hygiene advisory via external `alint` (profile-aware,
                              # NON-BLOCKING). auto = run if installed else info-skip;
                              # enabled = warn if missing; disabled = never run. Ships an

--- a/src/hyperi_ci/config/droast/droast.toml
+++ b/src/hyperi_ci/config/droast/droast.toml
@@ -1,0 +1,22 @@
+# hyperi-ci default droast config -- shipped in the wheel, passed via
+# `droast --config`. A repo's own droast.toml (auto-discovered up to the .git
+# root) is used instead when present; this is only the zero-config default.
+#
+# min-severity MUST be "info". DF033 (.dockerignore effectiveness) and DF031
+# (npm install where npm ci belongs) are INFO-severity rules -- setting
+# "warning" (the intuitive advisory choice) silences the two findings droast is
+# here for, leaving only rules hadolint already covers. Do not "tidy" this up.
+min-severity = "info"
+
+# Two rules are skipped because they contradict HyperI's container standard:
+#   DF007 -- flags `COPY . .` outright. House policy is that `COPY . .` PLUS a
+#            correct .dockerignore is the RIGHT pattern; a mile-long explicit
+#            COPY list is worse on every axis. droast's own DF033 already checks
+#            the .dockerignore side, so DF007 is pure noise-against-policy here.
+#   DF012 -- wants a HEALTHCHECK on everything. Kubernetes ignores HEALTHCHECK
+#            entirely, so it is noise on any cluster-targeted image (most of ours).
+skip = ["DF007", "DF012"]
+
+# Technical output only -- the snarky "roast" messages are droast's charm on a
+# terminal but read as unprofessional in a PR annotation / job summary.
+no-roast = true

--- a/src/hyperi_ci/dispatch.py
+++ b/src/hyperi_ci/dispatch.py
@@ -34,7 +34,9 @@ from hyperi_ci.detect import detect_language
 from hyperi_ci.quality import (
     commit_validation,
     deprecated_files,
+    droast,
     gitleaks,
+    hadolint,
     repo_advisor,
     semgrep,
 )
@@ -204,6 +206,17 @@ def stage_quality(language: str, config: CIConfig, *, local: bool = False) -> in
         rc = semgrep.run(config, language=language)
         if rc != 0:
             return rc
+
+    # Dockerfile linting is cross-language too: hadolint GATES (blocks on
+    # error-severity, incl a broken RUN shell), droast ADVISES (cache ordering /
+    # .dockerignore, never blocks). Both auto-detect Dockerfiles and clean-skip
+    # a repo with none.
+    with group("hadolint Dockerfile linting"):
+        rc = hadolint.run(config)
+        if rc != 0:
+            return rc
+    with group("droast Dockerfile advisory"):
+        droast.run(config)
 
     # Commit-message validation. In CI this is the dedicated `commit-check`
     # workflow job - it runs on every merge to main (not just the

--- a/src/hyperi_ci/gitops_templates/CODEOWNERS
+++ b/src/hyperi_ci/gitops_templates/CODEOWNERS
@@ -4,7 +4,7 @@
 # Topology authors may co-own their topologies
 /topologies/  @{{ ORG }}/platform
 
-# Terraform changes — strict review
+# OpenTofu (.tf) changes — strict review
 /terraform/   @{{ ORG }}/platform @{{ ORG }}/sre
 
 # Docs — open to all platform-adjacent contributors

--- a/src/hyperi_ci/gitops_templates/README.md
+++ b/src/hyperi_ci/gitops_templates/README.md
@@ -12,8 +12,8 @@ the platform team owns lives here:
 - **`values/`** — Per-topology + per-environment values overrides
   applied on top of the umbrella charts by ArgoCD multi-source
   Applications.
-- **`terraform/`** — IaC for cluster provisioning. AWS (EKS) and
-  Rancher (RKE2) live here as sibling subtrees.
+- **`terraform/`** — OpenTofu IaC for cluster provisioning (`.tf`, run
+  with `tofu`). AWS (EKS) and Rancher (RKE2) live here as sibling subtrees.
 - **`docs/`** — Reference documentation rendered to GitHub Pages
   (MkDocs Material) and mirrored to GitBook for the public site.
 
@@ -83,7 +83,7 @@ K8s cluster
 | `hyperi-ci init-gitops <dir>` | Scaffold a new gitops repo (this) |
 | `helm install` | Install umbrella charts directly (non-ArgoCD) |
 | ArgoCD | Reconcile cluster state from `argocd/` |
-| Terraform | Provision AWS / Rancher infra under `terraform/` |
+| OpenTofu (`tofu`) | Provision AWS / Rancher infra under `terraform/` |
 | MkDocs Material | Render `docs/` → GitHub Pages |
 
 ## Contributing
@@ -95,5 +95,5 @@ Per `CODEOWNERS`, platform-team approval required for changes outside
 2. `helm lint` passing on the stitched umbrella (CI preview)
 3. One platform-team reviewer
 
-PRs to `terraform/` require a `terraform plan` artifact in the PR
+PRs to `terraform/` require a `tofu plan` artifact in the PR
 description.

--- a/src/hyperi_ci/gitops_templates/docs/concepts/architecture.md
+++ b/src/hyperi_ci/gitops_templates/docs/concepts/architecture.md
@@ -70,4 +70,4 @@ topology.yaml   ──► stitched umbrella chart ──► GHCR OCI registry
 - CODEOWNERS assigns review responsibility per directory.
 - AppProject manifests in ArgoCD constrain which repositories and clusters each
   set of Applications may target.
-- Terraform state is stored remotely with appropriate IAM/RBAC controls.
+- OpenTofu state is stored remotely with appropriate IAM/RBAC controls.

--- a/src/hyperi_ci/gitops_templates/docs/how-to/add-environment.md
+++ b/src/hyperi_ci/gitops_templates/docs/how-to/add-environment.md
@@ -74,7 +74,7 @@ automatically (if auto-sync is enabled). Otherwise, trigger a manual sync:
 argocd app sync <topology-name>-dr-production
 ```
 
-## Terraform
+## OpenTofu
 
 If the new environment requires new cloud infrastructure (VPC, EKS cluster, IAM),
-add it under `terraform/` and attach the `terraform plan` output to the PR.
+add it under `terraform/` and attach the `tofu plan` output to the PR.

--- a/src/hyperi_ci/gitops_templates/docs/operations/disaster-recovery.md
+++ b/src/hyperi_ci/gitops_templates/docs/operations/disaster-recovery.md
@@ -9,11 +9,11 @@ The entire cluster state is recoverable from this repo. All desired state is in 
 
 ### Steps
 
-1. **Provision a new cluster** using Terraform:
+1. **Provision a new cluster** using OpenTofu:
 
    ```bash
-   terraform -chdir=terraform/aws init
-   terraform -chdir=terraform/aws apply -var-file=environments/production.tfvars
+   tofu -chdir=terraform/aws init
+   tofu -chdir=terraform/aws apply -var-file=environments/production.tfvars
    ```
 
 2. **Install ArgoCD** on the new cluster:
@@ -78,7 +78,7 @@ helm upgrade --install ... /tmp/stitched/production
 
 | Component | RTO | RPO | Recovery method |
 |-----------|-----|-----|----------------|
-| Cluster | ~30 min | 0 (git is source of truth) | Terraform + bootstrap |
+| Cluster | ~30 min | 0 (git is source of truth) | OpenTofu + bootstrap |
 | ArgoCD | ~10 min | 0 | `kubectl apply -f argocd/` |
 | Application state | ~5 min | Depends on app | Helm install from stitch |
 

--- a/src/hyperi_ci/gitops_templates/pull_request_template.md
+++ b/src/hyperi_ci/gitops_templates/pull_request_template.md
@@ -7,7 +7,7 @@
 - [ ] `topologies/` (deployment composition)
 - [ ] `argocd/` (reconciliation config)
 - [ ] `values/` (env overrides)
-- [ ] `terraform/` (IaC) — `terraform plan` output attached
+- [ ] `terraform/` (IaC) — `tofu plan` output attached
 - [ ] `docs/` (reference documentation)
 - [ ] CI / workflows
 - [ ] Other (describe)

--- a/src/hyperi_ci/gitops_templates/terraform/README.md
+++ b/src/hyperi_ci/gitops_templates/terraform/README.md
@@ -1,7 +1,9 @@
-# Terraform
+# OpenTofu (IaC)
 
 Infrastructure-as-Code for the clusters and cloud resources that host HyperI
-deployments.
+deployments. HyperI uses **OpenTofu** (`tofu`), not Terraform - Terraform is
+being retired across the org. The `.tf` format is shared, and the directory is
+kept named `terraform/` by convention.
 
 ## Directory layout
 
@@ -20,27 +22,28 @@ terraform/
 
 ```bash
 # Initialise (first time or after module changes)
-terraform -chdir=terraform/aws init
+tofu -chdir=terraform/aws init
 
 # Preview changes
-terraform -chdir=terraform/aws plan -var-file=environments/staging.tfvars
+tofu -chdir=terraform/aws plan -var-file=environments/staging.tfvars
 
 # Apply
-terraform -chdir=terraform/aws apply -var-file=environments/staging.tfvars
+tofu -chdir=terraform/aws apply -var-file=environments/staging.tfvars
 ```
 
 ## CI integration
 
-The **Validate** workflow runs `terraform fmt -check` on pull requests. It does
-NOT run `plan` or `apply` — those require manual execution with appropriate cloud
-credentials.
+The **Validate** workflow runs `tofu fmt -check` on pull requests. It does NOT
+run `plan` or `apply` — those require manual execution with appropriate cloud
+credentials. Manifest / IaC security is scanned by `hyperi-ci lint-manifests`
+(Checkov covers the `.tf`).
 
-Attach the `terraform plan` output to the pull request body (use the **Terraform**
-scope checkbox in the PR template).
+Attach the `tofu plan` output to the pull request body (use the **IaC** scope
+checkbox in the PR template).
 
 ## State
 
-Terraform state is stored remotely. Never commit `*.tfstate`, `*.tfstate.backup`,
+OpenTofu state is stored remotely. Never commit `*.tfstate`, `*.tfstate.backup`,
 or `*.tfplan` files — they are `.gitignore`'d.
 
 ## Adding a new environment
@@ -48,4 +51,4 @@ or `*.tfplan` files — they are `.gitignore`'d.
 1. Copy an existing `environments/*.tfvars` and adjust values.
 2. Update `argocd/applicationsets/` to include the new cluster target.
 3. Open a PR — CI will validate formatting.
-4. After merge, run `terraform apply` with the new var file.
+4. After merge, run `tofu apply` with the new var file.

--- a/src/hyperi_ci/gitops_templates/workflows/validate.yaml
+++ b/src/hyperi_ci/gitops_templates/workflows/validate.yaml
@@ -14,8 +14,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  topologies:
-    name: Topology schema + helm lint
+  manifests:
+    name: k8s + IaC linting
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -28,45 +28,47 @@ jobs:
         uses: azure/setup-helm@v4
         with:
           version: v3.16.0
-      - name: Lint every topology
-        run: |
-          set -euo pipefail
-          for topo in topologies/*/; do
-            name=$(basename "$topo")
-            echo "::group::Validating $name"
-            hyperi-ci stitch "$topo" --output-dir "/tmp/stitched/$name" --skip-helm-dep-update --skip-helm-lint
-            helm lint "/tmp/stitched/$name"
-            echo "::endgroup::"
-          done
+      # kubeconform (schema GATE) + kube-linter (best-practice ADVISORY) +
+      # checkov (IaC security ADVISORY over k8s/helm/kustomize/terraform).
+      # kubeconform + kube-linter auto-install on Linux CI; checkov runs via uvx.
+      # A schema-invalid manifest fails this job; the advisories only report.
+      - name: Lint manifests, charts and IaC
+        run: hyperi-ci lint-manifests .
 
-  argocd:
-    name: ArgoCD manifest validation
+  topologies:
+    name: Topology stitch
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Argo CLI
+      - uses: astral-sh/setup-uv@v3
+        with:
+          enable-cache: true
+      - name: Install hyperi-ci
+        run: uv tool install hyperi-ci
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.16.0
+      # Verify each topology composes into a valid umbrella chart. Per-topology
+      # by nature; the stitch/lint logic lives in the hyperi-ci CLI, the shell
+      # only iterates the directories.
+      - name: Stitch every topology
         run: |
-          curl -sSL -o argocd https://github.com/argoproj/argo-cd/releases/latest/download/argocd-linux-amd64
-          chmod +x argocd
-          sudo mv argocd /usr/local/bin/
-      - name: Validate ApplicationSet + AppProject manifests
-        run: |
-          set -euo pipefail
-          for f in argocd/appprojects/*.yaml argocd/applicationsets/*.yaml argocd/bootstrap/*.yaml; do
-            [ -e "$f" ] || continue
-            kubectl --dry-run=client apply -f "$f" || true
+          shopt -s nullglob  # an absent/empty topologies/ runs zero iterations, not the literal glob
+          for topo in topologies/*/; do
+            hyperi-ci stitch "$topo" --output-dir "stitched/$(basename "$topo")" --skip-helm-dep-update
           done
 
-  terraform:
-    name: Terraform fmt + validate
+  opentofu:
+    name: OpenTofu fmt + validate
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     steps:
       - uses: actions/checkout@v4
-      - uses: hashicorp/setup-terraform@v3
-      - name: terraform fmt
-        run: |
-          set -euo pipefail
-          if [ -d terraform ]; then
-            terraform -chdir=terraform fmt -recursive -check
-          fi
+      # OpenTofu, not Terraform - Terraform is being retired across HyperI.
+      # The .tf format is shared, so `tofu fmt` checks the same files.
+      - uses: opentofu/setup-opentofu@v1
+      # -recursive at the repo root formats every .tf (in terraform/ or
+      # elsewhere) and exits 0 when there are none - no dir guard needed.
+      - name: tofu fmt
+        run: tofu fmt -recursive -check

--- a/src/hyperi_ci/languages/quality_common.py
+++ b/src/hyperi_ci/languages/quality_common.py
@@ -26,6 +26,10 @@ DEFAULT_TEST_PATHS = ["tests/"]
 
 _STRICT_TRUTHY = {"1", "true", "yes", "on"}
 
+# The only valid quality-tool modes. An out-of-vocabulary value is a typo, not a
+# silent request to disable the gate (see resolve_cross_tool_mode).
+_VALID_MODES = {"blocking", "warn", "disabled"}
+
 
 def strict_quality() -> bool:
     """Return True when strict quality mode is active.
@@ -90,6 +94,38 @@ def is_skipped(tool: str) -> bool:
     if is_ci():
         print(f"::warning title=hyperi-ci quality force-skip::{msg}")
     return True
+
+
+def resolve_cross_tool_mode(
+    config: CIConfig, tool: str, default: str = "blocking"
+) -> str:
+    """Resolve mode for a cross-language quality tool (``quality.<tool>``).
+
+    Unlike :func:`resolve_tool_mode` (per-language ``quality.<lang>.<tool>``),
+    this reads the top-level ``quality.<tool>`` key shared by gitleaks, semgrep,
+    hadolint, droast, kubeconform, kube-linter and Checkov.
+
+    ``quality.<tool>`` may be a plain mode string (``blocking`` / ``warn`` /
+    ``disabled``) OR a dict carrying a ``mode`` plus tool options (Checkov's
+    ``frameworks`` / ``skip``, kubeconform's ``schema_locations``) - a bare
+    string keeps the options at their defaults. A force-skip wins; otherwise
+    strict upgrades a ``warn`` to ``blocking``.
+    """
+    if is_skipped(tool):
+        return "disabled"
+    raw = config.get(f"quality.{tool}", default)
+    mode = (
+        str(raw.get("mode", default) if isinstance(raw, dict) else raw).strip().lower()
+    )
+    # A typo (`block`, `enabled`, `true`) must NOT silently downgrade a gate to
+    # advisory - warn loudly and fall back to the tool's default instead.
+    if mode not in _VALID_MODES:
+        warn(
+            f"quality.{tool}: unknown mode '{mode}' - expected "
+            f"blocking / warn / disabled; using '{default}'"
+        )
+        mode = default
+    return apply_strict(mode)
 
 
 def resolve_tool_mode(tool: str, config: CIConfig, language: str) -> str:

--- a/src/hyperi_ci/quality/checkov.py
+++ b/src/hyperi_ci/quality/checkov.py
@@ -1,0 +1,126 @@
+# Project:   HyperI CI
+# File:      src/hyperi_ci/quality/checkov.py
+# Purpose:   Checkov IaC security scanning (ADVISORY, Path B)
+#
+# License:   BUSL-1.1 - HYPERI PTY LIMITED
+# Copyright: (c) 2026 HYPERI PTY LIMITED
+"""Checkov IaC security scanning - the k8s + IaC security ADVISORY.
+
+Checkov is the security/misconfiguration layer: it reads Kubernetes manifests,
+Helm charts, Kustomize AND Terraform/OpenTofu, auto-templating Helm/Kustomize
+itself (no pre-render needed). One tool covers dfe-infra's charts and its `.tf`
+- which is why it was chosen over Kubescape (Kubescape cannot scan OpenTofu).
+
+Installed the same way as semgrep - `uvx checkov`, since uv is already a hard
+dependency of every hyperi-ci project (no new tool manager).
+
+**Advisory by default** (`warn`): its 1000+ policies are broad, and retrofitting
+them onto an existing estate as a hard gate would redline every CI on day one.
+A repo can escalate to `blocking` once tuned. Scoped to the relevant frameworks
+and given a skip-list (e.g. External-Secrets `ExternalSecret` CRs trip Checkov's
+plaintext-secret checks) so it does not overlap gitleaks (secrets) or hadolint
+(Dockerfiles). Findings come from Checkov's SARIF output.
+"""
+
+from __future__ import annotations
+
+import shutil
+import tempfile
+from pathlib import Path
+
+from hyperi_ci.common import info, run_cmd, warn
+from hyperi_ci.config import CIConfig
+from hyperi_ci.languages.quality_common import resolve_cross_tool_mode
+from hyperi_ci.quality import findings as fdg
+from hyperi_ci.tools import missing_tool_notice
+
+_DEFAULT_FRAMEWORKS = ["kubernetes", "helm", "kustomize", "terraform"]
+# Never scan the worktree duplicate trees or scratch (regex, matched by Checkov
+# --skip-path against the path).
+_DEFAULT_SKIP_PATHS = [r".*/\.worktrees/.*", r".*/\.tmp/.*"]
+
+
+def _resolve_mode(config: CIConfig) -> str:
+    """Resolve Checkov's mode: ``warn`` (default) / ``blocking`` / ``disabled``."""
+    return resolve_cross_tool_mode(config, "checkov", "warn")
+
+
+def _base_cmd() -> list[str] | None:
+    """Return the checkov invocation (direct or via uvx), or None if absent."""
+    if shutil.which("checkov"):
+        return ["checkov"]
+    if shutil.which("uvx"):
+        return ["uvx", "checkov"]
+    return None
+
+
+def run(root: Path, config: CIConfig, *, sarif_path: str | Path | None = None) -> int:
+    """Scan ``root`` for IaC misconfigurations. Returns exit code.
+
+    0 = clean / advisory / skipped / missing-tool; 1 = a ``blocking`` gate hit a
+    finding. Default mode is ``warn`` (advisory), so day-one it never fails.
+    """
+    mode = _resolve_mode(config)
+    if mode == "disabled":
+        info("  checkov: disabled")
+        return 0
+
+    base = _base_cmd()
+    if base is None:
+        # Advisory install path (uvx) - a missing tool warn-skips, never fatal.
+        warn(missing_tool_notice("checkov"))
+        return 0
+
+    frameworks = config.get("quality.checkov.frameworks", _DEFAULT_FRAMEWORKS)
+    if not isinstance(frameworks, list):
+        frameworks = _DEFAULT_FRAMEWORKS
+    skip_checks = config.get("quality.checkov.skip", [])
+    skip_paths = list(_DEFAULT_SKIP_PATHS)
+    extra_paths = config.get("quality.checkov.skip_paths", [])
+    if isinstance(extra_paths, list):
+        skip_paths.extend(str(x) for x in extra_paths)
+
+    with tempfile.TemporaryDirectory(prefix="hyperi-checkov-") as out_dir:
+        cmd = [
+            *base,
+            "-d",
+            str(root),
+            "--framework",
+            *[str(f) for f in frameworks],
+            "--output",
+            "sarif",
+            "--output-file-path",
+            out_dir,
+            "--soft-fail",  # exit 0 regardless; WE decide the gate from findings
+            "--compact",
+            "--quiet",
+        ]
+        for sp in skip_paths:
+            cmd += ["--skip-path", sp]
+        if isinstance(skip_checks, list):
+            for chk in skip_checks:
+                cmd += ["--skip-check", str(chk)]
+
+        info(f"  checkov: scanning {root} ({', '.join(str(f) for f in frameworks)})...")
+        try:
+            run_cmd(cmd, check=False, capture=True)
+        except OSError as exc:
+            warn(f"  checkov could not be run ({exc}) - advisory only, not failing.")
+            return 0
+
+        sarif_file = Path(out_dir) / "results_sarif.sarif"
+        text = sarif_file.read_text(encoding="utf-8") if sarif_file.exists() else ""
+
+    found = fdg.parse_sarif(text, "checkov")
+    dropped = fdg.surface("checkov", found, sarif_path=sarif_path)
+    if dropped:
+        info(f"  checkov: +{dropped} more finding(s) in the job summary")
+
+    if not found:
+        info("  checkov: no findings")
+        return 0
+    if mode == "blocking":
+        warn(f"  checkov: {len(found)} finding(s) must be fixed")
+        return 1
+    warn(f"  checkov: {len(found)} finding(s) (non-blocking)")
+    return 0

--- a/src/hyperi_ci/quality/droast.py
+++ b/src/hyperi_ci/quality/droast.py
@@ -1,0 +1,84 @@
+# Project:   HyperI CI
+# File:      src/hyperi_ci/quality/droast.py
+# Purpose:   droast Dockerfile linting (cross-language ADVISORY, dispatch-level)
+#
+# License:   BUSL-1.1 - HYPERI PTY LIMITED
+# Copyright: (c) 2026 HYPERI PTY LIMITED
+"""droast Dockerfile linting - the container ADVISORY.
+
+droast (immanuwell/dockerfile-roast) catches three cache/hygiene problems
+hadolint has no rule for - broad ``COPY`` before install (DF070, the cache
+killer), ``.dockerignore`` effectiveness (DF033), and ``npm install`` where
+``npm ci`` belongs (DF031) - which map onto the container standard's headline
+lessons.
+
+**Advisory only, always.** The project is young (created 2026-04-12, one
+maintainer), so it NEVER fails a build regardless of config - it surfaces
+recommendations and returns 0, like the alint advisory. ``quality.droast:
+disabled`` turns it off entirely.
+
+droast emits standard SARIF 2.1.0, which we parse (via the shared SARIF
+parser) rather than its bespoke JSON, then surface through the shared layer.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from hyperi_ci.common import get_exclude_dirs, info, run_cmd, warn
+from hyperi_ci.config import CIConfig
+from hyperi_ci.languages.quality_common import resolve_cross_tool_mode
+from hyperi_ci.quality import findings as fdg
+from hyperi_ci.quality.targets import discover_dockerfiles
+from hyperi_ci.tools import find_tool
+
+# Shipped default config (skip DF007/DF012, min-severity=info, no-roast).
+# Packaged under hyperi_ci/config/ so it travels in the wheel; config/ is a
+# sibling of quality/ inside the package.
+_DEFAULT_CONFIG = (
+    Path(__file__).resolve().parents[1] / "config" / "droast" / "droast.toml"
+)
+
+
+def run(config: CIConfig, *, sarif_path: str | Path | None = None) -> int:
+    """Run droast over every Dockerfile. ALWAYS returns 0 - never gates.
+
+    ``quality.droast: disabled`` skips it. Otherwise findings surface through
+    the shared layer at their configured severity and the build carries on.
+    """
+    if resolve_cross_tool_mode(config, "droast", "warn") == "disabled":
+        info("  droast: disabled")
+        return 0
+
+    dockerfiles = discover_dockerfiles(
+        Path.cwd(), exclude_dirs=get_exclude_dirs(config._raw)
+    )
+    if not dockerfiles:
+        info("  droast: no Dockerfile found - skipping")
+        return 0
+
+    exe = find_tool("droast", recommended=False)
+    if not exe:
+        return 0  # advisory: a missing droast info-skips, never fails
+
+    # A repo's own droast.toml (auto-discovered up to the .git root) wins; else
+    # pass the shipped default so the advisory works with zero per-repo config.
+    cmd = [exe, "--no-fail", "--format", "sarif"]
+    if not (Path.cwd() / "droast.toml").exists():
+        cmd += ["--config", str(_DEFAULT_CONFIG)]
+    cmd += [str(p.relative_to(Path.cwd())) for p in dockerfiles]
+
+    info(f"  droast: advising on {len(dockerfiles)} Dockerfile(s)...")
+    try:
+        result = run_cmd(cmd, check=False, capture=True)
+    except OSError as exc:
+        warn(f"  droast could not be run ({exc}) - advisory only, not failing.")
+        return 0
+
+    found = fdg.parse_sarif(result.stdout, "droast")
+    dropped = fdg.surface("droast", found, sarif_path=sarif_path)
+    if found:
+        warn(f"  droast: {len(found)} advisory finding(s)")
+        if dropped:
+            info(f"  droast: +{dropped} more in the job summary")
+    return 0

--- a/src/hyperi_ci/quality/findings.py
+++ b/src/hyperi_ci/quality/findings.py
@@ -1,0 +1,376 @@
+# Project:   HyperI CI
+# File:      src/hyperi_ci/quality/findings.py
+# Purpose:   Shared finding surface for the linting tools (annotations + job
+#            summary + SARIF), with a step-global annotation budget
+#
+# License:   BUSL-1.1 - HYPERI PTY LIMITED
+# Copyright: (c) 2026 HYPERI PTY LIMITED
+"""Shared finding surface for the container / k8s / IaC linting tools.
+
+hadolint, droast, kubeconform, kube-linter and Checkov each emit their own
+JSON. Rather than let each one surface findings its own way (native
+annotations here, SARIF there, plain log elsewhere), every tool module parses
+its JSON into a normalised :class:`Finding` list and hands it to :func:`surface`.
+One code path then decides HOW findings appear, uniformly, in three layers:
+
+1. **GitHub annotations** (``::error::`` / ``::warning::`` / ``::notice::``) -
+   a BOUNDED set of inline pointers, errors first. Portable, needs no token,
+   works on every repo including private and forks.
+2. **Job summary** (``$GITHUB_STEP_SUMMARY`` markdown table) - the findings
+   list, bounded at 1000 rows with a truncation note (to stay under GitHub's
+   1MiB/step ceiling). This is the safety net for the annotation cap.
+3. **SARIF** - written only when a path is configured (opt-in). Writing the
+   file is always safe; UPLOADING it into code scanning needs GitHub Code
+   Security (paid on private repos), so the upload is the workflow's job, not
+   ours - we never try to upload and never trigger the "must enable" error.
+
+The annotation budget is the subtle part. GitHub caps annotations at **10
+error + 10 warning per STEP** (50 per job), and SILENTLY drops the rest with no
+feedback - a static analyser that emits 40 findings looks like it emitted 10.
+Every tool that surfaces through here draws from ONE process-global budget (a
+module-level :class:`_AnnotationBudget`), so the tools sharing a process cannot
+between them exceed the per-step cap. When it is exhausted the remaining
+findings still land in the job summary, which is uncapped - nothing is ever
+silently lost.
+
+In practice the budget couples the ``surface()`` users that run in the same
+process: hadolint + droast inside ``hyperi-ci run quality`` (gitleaks/semgrep
+emit their own output and do not use this surface), and kubeconform +
+kube-linter + Checkov inside the separate ``lint-manifests`` process - which,
+being a distinct step, correctly starts with its own fresh budget.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from hyperi_ci.common import is_github_actions, warn
+
+# Cap the rows written to one job-summary section. GitHub truncates a step
+# summary at 1 MiB; a bounded table plus a "truncated" note keeps a pathological
+# findings count from silently hitting that ceiling (the annotation cap's twin).
+_MAX_SUMMARY_ROWS = 1000
+
+# GitHub Actions per-step annotation limits (10 error + 10 warning). We budget
+# each level to its own ceiling and prioritise errors. `notice` has no
+# documented separate ceiling, but is bounded here too so an advisory tool
+# cannot flood the run summary annotations.
+_ANNOTATION_CAP = 10
+
+# Normalised severity -> GitHub workflow-command keyword. Tools speak
+# error/warning/info/style/note; we fold everything to the three GitHub levels.
+_GH_COMMAND = {"error": "error", "warning": "warning", "notice": "notice"}
+
+# Normalised severity -> SARIF result level (SARIF uses `note`, not `notice`).
+_SARIF_LEVEL = {"error": "error", "warning": "warning", "notice": "note"}
+
+_LEVEL_ALIASES = {
+    "error": "error",
+    "err": "error",
+    "warning": "warning",
+    "warn": "warning",
+    "info": "notice",
+    "information": "notice",
+    "style": "notice",
+    "note": "notice",
+    "notice": "notice",
+}
+
+
+def normalise_level(raw: str) -> str:
+    """Fold a tool's severity word to one of ``error`` / ``warning`` / ``notice``.
+
+    Unknown severities default to ``warning`` - visible but not build-failing,
+    the safe middle for an unrecognised signal.
+    """
+    return _LEVEL_ALIASES.get(str(raw).strip().lower(), "warning")
+
+
+@dataclass(frozen=True)
+class Finding:
+    """One normalised finding from any linting tool.
+
+    ``level`` is already folded to ``error`` / ``warning`` / ``notice`` (use
+    :func:`normalise_level` at parse time). ``line`` is 1-indexed or ``None``
+    when the tool reports no location.
+    """
+
+    tool: str
+    path: str
+    line: int | None
+    level: str
+    rule: str
+    message: str
+    url: str = ""
+
+
+@dataclass
+class _AnnotationBudget:
+    """Step-global remaining-annotation counters, one per GitHub level.
+
+    Module-level singleton (:data:`_BUDGET`) so every tool in the one quality
+    process draws from the same pool. :func:`reset_annotation_budget` restores
+    it (used by tests and available if a caller wants a clean step).
+    """
+
+    remaining: dict[str, int] = field(
+        default_factory=lambda: {
+            "error": _ANNOTATION_CAP,
+            "warning": _ANNOTATION_CAP,
+            "notice": _ANNOTATION_CAP,
+        }
+    )
+
+    def take(self, level: str) -> bool:
+        """Consume one annotation of ``level``; return False if none remain."""
+        if self.remaining.get(level, 0) <= 0:
+            return False
+        self.remaining[level] -= 1
+        return True
+
+
+_BUDGET = _AnnotationBudget()
+
+
+def reset_annotation_budget() -> None:
+    """Restore the step-global annotation budget to full."""
+    _BUDGET.remaining = {
+        "error": _ANNOTATION_CAP,
+        "warning": _ANNOTATION_CAP,
+        "notice": _ANNOTATION_CAP,
+    }
+
+
+def _prop_val(value: str) -> str:
+    """Sanitise a workflow-command PROPERTY value (file / title / rule).
+
+    Property fields are comma- and ``::``-delimited, so repo-controlled content
+    (a manifest ``kind``, a filename with a comma) could otherwise inject or
+    spoof another property. Strip the delimiters and newlines - cosmetic fields,
+    so replacing is fine.
+    """
+    return (
+        value.replace(",", " ").replace("::", " ").replace("\r", " ").replace("\n", " ")
+    )
+
+
+def _annotation_line(f: Finding) -> str:
+    """Render one GitHub workflow-command annotation line for ``f``."""
+    cmd = _GH_COMMAND[f.level]
+    rule = _prop_val(f.rule)
+    props = (
+        [f"title=hyperi-ci {_prop_val(f.tool)}: {rule}"]
+        if f.rule
+        else [f"title=hyperi-ci {_prop_val(f.tool)}"]
+    )
+    if f.path:
+        props.insert(0, f"file={_prop_val(f.path)}")
+        if f.line is not None:
+            props.append(f"line={f.line}")
+    # Newlines in the message would break the single-line command; encode them
+    # the way GitHub expects (%0A) so a multi-line message survives intact.
+    msg = f.message.replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A")
+    return f"::{cmd} {','.join(props)}::{msg}"
+
+
+def emit_annotations(findings: list[Finding]) -> int:
+    """Emit up-to-budget GitHub annotations for ``findings``, errors first.
+
+    Returns the number of findings that could NOT be annotated because the
+    step-global budget was exhausted - the caller notes "+N more, see summary"
+    so an exhausted budget is visible rather than a silent drop. Outside GitHub
+    Actions this is a no-op (returns 0); the job summary and log carry the
+    findings there.
+    """
+    if not is_github_actions():
+        return 0
+    order = {"error": 0, "warning": 1, "notice": 2}
+    dropped = 0
+    for f in sorted(findings, key=lambda x: order.get(x.level, 3)):
+        if _BUDGET.take(f.level):
+            print(_annotation_line(f))
+        else:
+            dropped += 1
+    return dropped
+
+
+def _summary_table(findings: list[Finding]) -> str:
+    """Render a markdown table of ``findings`` for the job summary."""
+    rows = ["| Severity | Rule | Location | Message |", "| --- | --- | --- | --- |"]
+    for f in findings:
+        loc = f.path + (f":{f.line}" if f.line is not None else "")
+        # Escape pipes so a message containing `|` does not break the table.
+        msg = f.message.replace("|", "\\|").replace("\n", " ")
+        rule = f"[{f.rule}]({f.url})" if f.url else f.rule
+        rows.append(f"| {f.level} | {rule} | {loc} | {msg} |")
+    return "\n".join(rows)
+
+
+def append_job_summary(tool: str, findings: list[Finding]) -> None:
+    """Append a ``tool`` section (full findings table) to the job summary.
+
+    Writes to ``$GITHUB_STEP_SUMMARY`` when set (GitHub Actions); a no-op
+    otherwise. The list goes here bounded at ``_MAX_SUMMARY_ROWS`` (to stay
+    under the 1MiB/step ceiling), so it is the authoritative record even when
+    the annotation budget truncated.
+    """
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if not summary_path or not findings:
+        return
+    shown = findings[:_MAX_SUMMARY_ROWS]
+    heading = f"### {tool}: {len(findings)} finding(s)\n\n"
+    block = heading + _summary_table(shown)
+    if len(findings) > len(shown):
+        block += f"\n\n_... {len(findings) - len(shown)} more findings truncated (see the log)._"
+    block += "\n\n"
+    # Best-effort surfacing: a write failure (unwritable summary path) must never
+    # crash the tool - especially an advisory, which is contractually non-fatal.
+    try:
+        with Path(summary_path).open("a", encoding="utf-8", newline="\n") as fh:
+            fh.write(block)
+    except OSError as exc:
+        warn(f"  could not write job summary for {tool}: {exc}")
+
+
+def write_sarif(tool: str, findings: list[Finding], path: str | Path) -> None:
+    """Write (or append a run to) a SARIF 2.1.0 file at ``path``.
+
+    Multiple tools in one stage can target the same ``path``; each call appends
+    its own ``run`` so the result is a single multi-run SARIF the workflow
+    uploads ONCE. Writing the file is always safe - the code-scanning UPLOAD
+    (which needs GitHub Code Security, paid on private repos) is the workflow's
+    responsibility, gated there, never attempted here.
+    """
+    p = Path(path)
+    doc: dict = {
+        "version": "2.1.0",
+        "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+        "runs": [],
+    }
+    if p.exists():
+        try:
+            existing = json.loads(p.read_text(encoding="utf-8"))
+            if isinstance(existing, dict) and isinstance(existing.get("runs"), list):
+                doc = existing
+        except (OSError, json.JSONDecodeError):
+            pass  # start fresh rather than fail the lint on a corrupt prior file
+
+    rules: dict[str, dict] = {}
+    results = []
+    for f in findings:
+        if f.rule and f.rule not in rules:
+            rule: dict = {"id": f.rule}
+            if f.url:
+                rule["helpUri"] = f.url
+            rules[f.rule] = rule
+        region = {"startLine": f.line} if f.line is not None else {}
+        results.append(
+            {
+                "ruleId": f.rule or tool,
+                "level": _SARIF_LEVEL.get(f.level, "warning"),
+                "message": {"text": f.message},
+                "locations": [
+                    {
+                        "physicalLocation": {
+                            "artifactLocation": {"uri": f.path},
+                            **({"region": region} if region else {}),
+                        }
+                    }
+                ]
+                if f.path
+                else [],
+            }
+        )
+    doc["runs"].append(
+        {
+            "tool": {"driver": {"name": tool, "rules": list(rules.values())}},
+            "results": results,
+        }
+    )
+    # Best-effort: an unwritable sarif path must not crash the tool (advisories
+    # are contractually non-fatal; a gate should fail on findings, not on a
+    # surfacing IO error).
+    try:
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(json.dumps(doc, indent=2), encoding="utf-8")
+    except OSError as exc:
+        warn(f"  could not write SARIF for {tool}: {exc}")
+
+
+def parse_sarif(text: str, tool: str) -> list[Finding]:
+    """Parse a tool's SARIF 2.1.0 output into normalised :class:`Finding` s.
+
+    Several tools (droast, kube-linter, Checkov) emit SARIF, whose schema is
+    fixed and standard - so parsing SARIF is far more robust than each tool's
+    bespoke JSON, whose field names we cannot always pin down. One parser
+    serves them all. ``tool`` labels the findings; the SARIF driver name is not
+    trusted for that (it varies).
+
+    Tolerant by design: a malformed or empty SARIF yields ``[]`` rather than
+    raising, because an advisory tool must never turn a parse hiccup into a
+    failed lint.
+    """
+    try:
+        doc = json.loads(text)
+    except json.JSONDecodeError:
+        return []
+    if not isinstance(doc, dict):
+        return []
+    # SARIF folds `note`/`none` down here; unknown -> normalise_level's default.
+    sarif_to_level = {
+        "error": "error",
+        "warning": "warning",
+        "note": "notice",
+        "none": "notice",
+    }
+    out: list[Finding] = []
+    for run in doc.get("runs", []) or []:
+        # Rule helpUri lookup, so a finding can carry its docs link.
+        rule_urls: dict[str, str] = {}
+        driver = (run.get("tool") or {}).get("driver") or {}
+        for rule in driver.get("rules", []) or []:
+            rid = rule.get("id")
+            if rid and rule.get("helpUri"):
+                rule_urls[rid] = rule["helpUri"]
+        for res in run.get("results", []) or []:
+            rule_id = res.get("ruleId") or ""
+            level = sarif_to_level.get(str(res.get("level", "")).lower(), "")
+            level = level or normalise_level(str(res.get("level", "warning")))
+            message = ((res.get("message") or {}).get("text")) or ""
+            path, line = "", None
+            locs = res.get("locations") or []
+            if locs:
+                phys = (locs[0] or {}).get("physicalLocation") or {}
+                path = (phys.get("artifactLocation") or {}).get("uri") or ""
+                line = (phys.get("region") or {}).get("startLine")
+            out.append(
+                Finding(
+                    tool=tool,
+                    path=path,
+                    line=line,
+                    level=level,
+                    rule=rule_id,
+                    message=message,
+                    url=rule_urls.get(rule_id, ""),
+                )
+            )
+    return out
+
+
+def surface(
+    tool: str, findings: list[Finding], *, sarif_path: str | Path | None = None
+) -> int:
+    """Surface ``findings`` across all layers: annotations, summary, optional SARIF.
+
+    Returns the count of findings that overflowed the annotation budget (so the
+    caller can log "+N more, see summary"). The full list is always in the job
+    summary and, when ``sarif_path`` is set, in the SARIF file.
+    """
+    dropped = emit_annotations(findings)
+    append_job_summary(tool, findings)
+    if sarif_path is not None:
+        write_sarif(tool, findings, sarif_path)
+    return dropped

--- a/src/hyperi_ci/quality/hadolint.py
+++ b/src/hyperi_ci/quality/hadolint.py
@@ -1,0 +1,188 @@
+# Project:   HyperI CI
+# File:      src/hyperi_ci/quality/hadolint.py
+# Purpose:   hadolint Dockerfile linting (cross-language gate, dispatch-level)
+#
+# License:   BUSL-1.1 - HYPERI PTY LIMITED
+# Copyright: (c) 2026 HYPERI PTY LIMITED
+"""hadolint Dockerfile linting - the container GATE.
+
+hadolint is the one Dockerfile linter allowed to FAIL a build, because it
+lints the shell inside ``RUN`` instructions via ShellCheck - a correctness
+check nothing else in this space offers. Runs once at the dispatch level (like
+gitleaks/semgrep) over every Dockerfile in the repo; auto-detects and clean-
+skips a repo with none.
+
+**Gate semantics.** hadolint's own rules carry severities (error / warning /
+info / style). We gate on ERROR severity only: in ``blocking`` mode an
+error-level finding fails the stage, while warning/info/style are surfaced but
+never fatal. That is deliberate - the estate's routine noise (DL3008 apt-pin,
+DL4006 pipefail) is all warning-tier, so the gate is near-silent day one while
+still catching a broken ``RUN`` shell. ``warn`` mode never fails; ``--strict``
+upgrades ``warn`` to ``blocking``.
+
+Findings surface through the shared layer (:mod:`hyperi_ci.quality.findings`):
+bounded annotations + full job-summary table + optional SARIF.
+"""
+
+from __future__ import annotations
+
+import json
+import platform
+from pathlib import Path
+
+from hyperi_ci.common import (
+    error,
+    get_exclude_dirs,
+    info,
+    is_ci,
+    run_cmd,
+    success,
+    warn,
+)
+from hyperi_ci.config import CIConfig
+from hyperi_ci.languages.quality_common import resolve_cross_tool_mode
+from hyperi_ci.quality import findings as fdg
+from hyperi_ci.quality.install import install_ci_binary
+from hyperi_ci.quality.targets import discover_dockerfiles
+from hyperi_ci.tools import missing_tool_notice
+
+# Mirrors `tools.hadolint` in config/versions.yaml (the SSoT). config/ ships
+# outside the wheel, so the value is copied here; update-versions.py --fix keeps
+# them in sync via the marker below. Do not hand-edit.
+# hyperi-ci:pin tools.hadolint
+_HADOLINT_VERSION = "v2.14.0"
+
+
+def _install_hadolint() -> str | None:
+    """Return a hadolint path, installing the pinned static binary on Linux CI.
+
+    hadolint is baked into the ARC runner image, but consumer CI can run on a
+    vanilla GitHub runner where it is absent. It is a single static binary, so
+    fetch the pinned release rather than let a blocking gate hard-fail for a
+    missing tool. Returns None off-CI / non-Linux (the caller warn-skips locally).
+    """
+    arch = "x86_64" if platform.machine() in ("x86_64", "AMD64") else "arm64"
+    url = (
+        f"https://github.com/hadolint/hadolint/releases/download/"
+        f"{_HADOLINT_VERSION}/hadolint-Linux-{arch}"
+    )
+    return install_ci_binary("hadolint", url)
+
+
+def _rule_url(code: str) -> str:
+    """Docs link for a hadolint (DL*) or embedded ShellCheck (SC*) rule."""
+    if code.startswith("DL"):
+        return f"https://github.com/hadolint/hadolint/wiki/{code}"
+    if code.startswith("SC"):
+        return f"https://www.shellcheck.net/wiki/{code}"
+    return ""
+
+
+def _parse(stdout: str) -> list[fdg.Finding]:
+    """Parse hadolint ``--format json`` output into normalised findings.
+
+    hadolint emits a flat array of ``{file, line, column, level, code,
+    message}``. A blank / non-array payload yields ``[]`` (no findings).
+    """
+    try:
+        raw = json.loads(stdout or "[]")
+    except json.JSONDecodeError:
+        return []
+    if not isinstance(raw, list):
+        return []
+    out: list[fdg.Finding] = []
+    for item in raw:
+        if not isinstance(item, dict):
+            continue
+        code = str(item.get("code", ""))
+        out.append(
+            fdg.Finding(
+                tool="hadolint",
+                path=str(item.get("file", "")),
+                line=item.get("line"),
+                level=fdg.normalise_level(str(item.get("level", "warning"))),
+                rule=code,
+                message=str(item.get("message", "")),
+                url=_rule_url(code),
+            )
+        )
+    return out
+
+
+def _resolve_mode(config: CIConfig) -> str:
+    """Resolve hadolint's mode: ``blocking`` (default) / ``warn`` / ``disabled``."""
+    return resolve_cross_tool_mode(config, "hadolint", "blocking")
+
+
+def run(config: CIConfig, *, sarif_path: str | Path | None = None) -> int:
+    """Run hadolint over every Dockerfile in the repo.
+
+    Returns exit code (0 = pass / advisory / skipped; 1 = a blocking gate hit an
+    error-severity finding, or the tool is required-but-missing in CI).
+    """
+    mode = _resolve_mode(config)
+    if mode == "disabled":
+        info("  hadolint: disabled")
+        return 0
+
+    dockerfiles = discover_dockerfiles(
+        Path.cwd(), exclude_dirs=get_exclude_dirs(config._raw)
+    )
+    if not dockerfiles:
+        info("  hadolint: no Dockerfile found - skipping")
+        return 0
+
+    exe = _install_hadolint()
+    if not exe:
+        if mode == "blocking" and is_ci():
+            error(missing_tool_notice("hadolint"))
+            return 1
+        warn(missing_tool_notice("hadolint"))
+        return 0
+
+    # --no-fail: hadolint always exits 0 and emits the full JSON report; WE
+    # decide the gate from the parsed severities, so all gate logic is in one
+    # place (and testable) rather than split across hadolint's exit code.
+    rels = [str(p.relative_to(Path.cwd())) for p in dockerfiles]
+    info(f"  hadolint: linting {len(rels)} Dockerfile(s)...")
+    try:
+        result = run_cmd(
+            [exe, "--no-fail", "--format", "json", *rels], check=False, capture=True
+        )
+    except OSError as exc:
+        # exec failure (a corrupt auto-installed binary, no exec bit). A gate
+        # that cannot run is not a pass - fail it in CI rather than crash.
+        warn(f"  hadolint could not be run ({exc})")
+        if mode == "blocking" and is_ci():
+            error("  hadolint could not complete - failing the gate")
+            return 1
+        return 0
+    found = _parse(result.stdout)
+
+    # --no-fail means hadolint exits 0 even WITH findings, so a non-zero exit
+    # with nothing parsed is the TOOL erroring (a drifted flag, a corrupt
+    # download that still chmod'd, OOM) - NOT a clean Dockerfile. A gate that
+    # scores a malfunctioning tool as green is the worst failure mode, so treat
+    # it as unvalidated: blocking-in-CI fails, otherwise warn and carry on.
+    if result.returncode != 0 and not found:
+        warn(
+            f"  hadolint exited {result.returncode} with no parseable output - tool error, not a clean pass"
+        )
+        if mode == "blocking" and is_ci():
+            error("  hadolint could not complete - failing the gate")
+            return 1
+        return 0
+
+    dropped = fdg.surface("hadolint", found, sarif_path=sarif_path)
+    if dropped:
+        info(f"  hadolint: +{dropped} more finding(s) in the job summary")
+
+    errors = [f for f in found if f.level == "error"]
+    if not found:
+        success("  hadolint: passed")
+        return 0
+    if mode == "blocking" and errors:
+        error(f"  hadolint: {len(errors)} error-severity finding(s) must be fixed")
+        return 1
+    warn(f"  hadolint: {len(found)} finding(s) (non-blocking)")
+    return 0

--- a/src/hyperi_ci/quality/install.py
+++ b/src/hyperi_ci/quality/install.py
@@ -1,0 +1,98 @@
+# Project:   HyperI CI
+# File:      src/hyperi_ci/quality/install.py
+# Purpose:   Install a pinned release binary on Linux CI (shared by the linters)
+#
+# License:   BUSL-1.1 - HYPERI PTY LIMITED
+# Copyright: (c) 2026 HYPERI PTY LIMITED
+"""Install a pinned static release binary on a Linux CI runner.
+
+hadolint, kubeconform and kube-linter are all small single static binaries
+fetched the same way: skip if already on PATH, skip off-CI / non-Linux (the
+caller warn-skips locally), else download the pinned release and drop it in
+``/usr/local/bin``. One helper rather than the same 25 lines copied per tool.
+
+Some ship as a raw binary (hadolint), others inside a ``.tar.gz``
+(kubeconform, kube-linter); ``tar_member`` selects the entry to extract.
+"""
+
+from __future__ import annotations
+
+import io
+import shutil
+import subprocess
+import sys
+import tarfile
+import tempfile
+from pathlib import Path
+
+from hyperi_ci.common import error, info, is_ci
+
+
+def install_ci_binary(
+    name: str, url: str, *, tar_member: str | None = None
+) -> str | None:
+    """Return a path to ``name``, installing the pinned release on Linux CI.
+
+    Returns the existing path if already installed; ``None`` off-CI / non-Linux
+    or on any download/extract failure (the caller decides whether that is
+    fatal). ``tar_member`` is the binary's name inside a ``.tar.gz`` (omit for a
+    raw-binary download).
+    """
+    exe = shutil.which(name)
+    if exe:
+        return exe
+    if not is_ci() or sys.platform != "linux":
+        return None
+
+    info(f"  Installing {name}...")
+    # -f: fail (empty body, non-zero exit) on an HTTP error instead of saving a
+    # 404/captive-portal HTML page and later chmod+exec'ing it as "the tool".
+    # --connect-timeout/--max-time give a HARD ceiling so a stalled mirror
+    # cannot hang the runner unbounded (the repo's no-unbounded-wait doctrine);
+    # the outer timeout= is a belt-and-braces backstop.
+    try:
+        dl = subprocess.run(
+            ["curl", "-fsSL", "--connect-timeout", "10", "--max-time", "180", url],
+            capture_output=True,
+            timeout=200,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        error(f"  Failed to download {name} (network error / timeout)")
+        return None
+    if dl.returncode != 0 or not dl.stdout:
+        error(f"  Failed to download {name} (curl exit {dl.returncode})")
+        return None
+
+    if tar_member:
+        try:
+            with tarfile.open(fileobj=io.BytesIO(dl.stdout), mode="r:gz") as tf:
+                member = next(
+                    (m for m in tf.getmembers() if Path(m.name).name == tar_member),
+                    None,
+                )
+                extracted = tf.extractfile(member) if member else None
+                data = extracted.read() if extracted else None
+        except (tarfile.TarError, OSError):
+            data = None
+        if not data:
+            error(f"  {name}: '{tar_member}' not found in release archive")
+            return None
+    else:
+        data = dl.stdout
+
+    tmp_path = ""
+    try:
+        with tempfile.NamedTemporaryFile(delete=False) as tmp:
+            tmp.write(data)
+            tmp_path = tmp.name
+        dest = Path("/usr/local/bin") / name
+        # `sudo` can be absent / non-passwordless on a hardened runner - that is
+        # an install failure to report (None), NOT a traceback that crashes a
+        # blocking gate's whole quality stage.
+        subprocess.run(["sudo", "mv", tmp_path, str(dest)], check=True)
+        subprocess.run(["sudo", "chmod", "+x", str(dest)], check=True)
+    except (OSError, subprocess.CalledProcessError) as exc:
+        error(f"  Failed to install {name}: {exc}")
+        Path(tmp_path).unlink(missing_ok=True)  # do not leak the temp on failure
+        return None
+    return shutil.which(name)

--- a/src/hyperi_ci/quality/kube_linter.py
+++ b/src/hyperi_ci/quality/kube_linter.py
@@ -1,0 +1,89 @@
+# Project:   HyperI CI
+# File:      src/hyperi_ci/quality/kube_linter.py
+# Purpose:   kube-linter k8s best-practice linting (ADVISORY, Path B)
+#
+# License:   BUSL-1.1 - HYPERI PTY LIMITED
+# Copyright: (c) 2026 HYPERI PTY LIMITED
+"""kube-linter Kubernetes best-practice linting - the k8s ADVISORY.
+
+Where kubeconform asks "is this a valid manifest?", kube-linter asks "is this a
+GOOD one?" - production-readiness and security best practices (no run-as-root,
+resource limits set, liveness/readiness probes, ...). It is advisory: it
+surfaces recommendations and NEVER fails the build.
+
+Unlike kubeconform, kube-linter templates Helm charts itself, so it takes the
+chart directories and plain manifests directly - no pre-render needed. It
+positions naturally on the RENDERED/chart side, adding the best-practice checks
+that plain ``helm lint`` does not do. A repo's own ``.kube-linter.yaml`` (auto-
+discovered) tunes the checks.
+
+Findings come from ``--format sarif`` and surface through the shared layer.
+"""
+
+from __future__ import annotations
+
+import platform
+from pathlib import Path
+
+from hyperi_ci.common import info, run_cmd, warn
+from hyperi_ci.config import CIConfig
+from hyperi_ci.languages.quality_common import resolve_cross_tool_mode
+from hyperi_ci.quality import findings as fdg
+from hyperi_ci.quality.install import install_ci_binary
+from hyperi_ci.tools import find_tool
+
+# hyperi-ci:pin tools.kube-linter
+_KUBE_LINTER_VERSION = "v0.8.3"
+
+
+def _install_kube_linter() -> str | None:
+    """Install the pinned kube-linter release on Linux CI (else None)."""
+    # Raw single binary (no tarball) - amd64 is `kube-linter-linux`, arm64 adds
+    # the `_arm64` suffix.
+    suffix = "" if platform.machine() in ("x86_64", "AMD64") else "_arm64"
+    url = (
+        f"https://github.com/stackrox/kube-linter/releases/download/"
+        f"{_KUBE_LINTER_VERSION}/kube-linter-linux{suffix}"
+    )
+    return install_ci_binary("kube-linter", url)
+
+
+def run(
+    targets: list[Path],
+    config: CIConfig,
+    *,
+    sarif_path: str | Path | None = None,
+) -> int:
+    """Lint ``targets`` (chart dirs + plain manifests). ALWAYS returns 0.
+
+    ``quality.kube_linter: disabled`` turns it off. Otherwise best-practice
+    findings surface through the shared layer and the build carries on.
+    """
+    if resolve_cross_tool_mode(config, "kube_linter", "warn") == "disabled":
+        info("  kube-linter: disabled")
+        return 0
+    if not targets:
+        info("  kube-linter: no charts or manifests - skipping")
+        return 0
+
+    # Auto-install on Linux CI; fall back to an already-present binary. Advisory,
+    # so a missing tool info-skips rather than failing.
+    exe = _install_kube_linter() or find_tool("kube-linter", recommended=False)
+    if not exe:
+        return 0
+
+    cmd = [exe, "lint", "--format", "sarif", *[str(p) for p in targets]]
+    info(f"  kube-linter: advising on {len(targets)} target(s)...")
+    try:
+        result = run_cmd(cmd, check=False, capture=True)
+    except OSError as exc:
+        warn(f"  kube-linter could not be run ({exc}) - advisory only, not failing.")
+        return 0
+
+    found = fdg.parse_sarif(result.stdout, "kube-linter")
+    dropped = fdg.surface("kube-linter", found, sarif_path=sarif_path)
+    if found:
+        warn(f"  kube-linter: {len(found)} advisory finding(s)")
+        if dropped:
+            info(f"  kube-linter: +{dropped} more in the job summary")
+    return 0

--- a/src/hyperi_ci/quality/kubeconform.py
+++ b/src/hyperi_ci/quality/kubeconform.py
@@ -1,0 +1,187 @@
+# Project:   HyperI CI
+# File:      src/hyperi_ci/quality/kubeconform.py
+# Purpose:   kubeconform k8s manifest schema validation (GATE, Path B)
+#
+# License:   BUSL-1.1 - HYPERI PTY LIMITED
+# Copyright: (c) 2026 HYPERI PTY LIMITED
+"""kubeconform Kubernetes manifest schema validation - the k8s GATE.
+
+A manifest that does not validate against the Kubernetes OpenAPI schema is a
+hard error, so kubeconform gates (blocking). It validates RENDERED manifests -
+Helm charts must be ``helm template``-d first (see
+:mod:`hyperi_ci.quality.render`); this module takes the resulting manifest
+files plus any already-plain manifests (Argo CRs, loose YAML).
+
+**CRD surface.** Real clusters carry many CRDs (Gateway API, Strimzi, Redpanda,
+CNPG, External Secrets, cert-manager, KEDA, ArgoCD, ...) that are not in the
+core schemas. Two mechanisms keep that from turning the gate into all-noise:
+
+* ``-schema-location`` points at the community CRD catalogue (datreeio), so a
+  large fraction of CRDs resolve to a real schema and ARE validated. ``default``
+  is kept first so the built-in k8s schemas still apply.
+* ``-ignore-missing-schemas`` skips (does not fail) a kind with no schema
+  anywhere - an unknown CRD is reported ``skipped``, not ``invalid``.
+
+Coverage caveat (surfaced, not hidden, in the spirit of the gitleaks #67 note):
+a ``skipped`` resource was NOT schema-checked, and for multi-source ArgoCD apps
+the rendered manifest here uses in-repo default values only. A green
+kubeconform gate is "no schema violations we could check", not "fully valid".
+"""
+
+from __future__ import annotations
+
+import json
+import platform
+from pathlib import Path
+
+from hyperi_ci.common import error, info, is_ci, run_cmd, success, warn
+from hyperi_ci.config import CIConfig
+from hyperi_ci.languages.quality_common import resolve_cross_tool_mode
+from hyperi_ci.quality import findings as fdg
+from hyperi_ci.quality.install import install_ci_binary
+from hyperi_ci.tools import missing_tool_notice
+
+# hyperi-ci:pin tools.kubeconform
+_KUBECONFORM_VERSION = "v0.8.0"
+
+# Community CRD schema catalogue. kubeconform expands the templated path per
+# resource; a CRD present in the catalogue validates for real, the rest are
+# skipped (with -ignore-missing-schemas) rather than failing the gate.
+_CRD_CATALOG = (
+    "https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/"
+    "{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json"
+)
+
+
+def _install_kubeconform() -> str | None:
+    """Install the pinned kubeconform release on Linux CI (else None)."""
+    arch = "amd64" if platform.machine() in ("x86_64", "AMD64") else "arm64"
+    url = (
+        f"https://github.com/yannh/kubeconform/releases/download/"
+        f"{_KUBECONFORM_VERSION}/kubeconform-linux-{arch}.tar.gz"
+    )
+    return install_ci_binary("kubeconform", url, tar_member="kubeconform")
+
+
+def _schema_locations(config: CIConfig) -> list[str]:
+    """Schema search path: built-in defaults, the CRD catalogue, then extras.
+
+    A repo adds cluster-specific CRD schema locations via
+    ``quality.kubeconform.schema_locations`` (a list) in .hyperi-ci.yaml.
+    """
+    locs = ["default", _CRD_CATALOG]
+    extra = config.get("quality.kubeconform.schema_locations", [])
+    if isinstance(extra, list):
+        locs.extend(str(x) for x in extra)
+    return locs
+
+
+def _parse(stdout: str) -> list[fdg.Finding]:
+    """Parse kubeconform ``-output json`` into findings (invalid/error only).
+
+    kubeconform emits ``{"resources": [{filename, kind, name, version, status,
+    msg}], "summary": {...}}``. Only ``invalid`` / ``error`` statuses are
+    findings; ``valid`` / ``skipped`` / ``empty`` are not. Status casing varies
+    across versions ("INVALID" vs "statusInvalid"), so match case-insensitively
+    on the substring.
+    """
+    try:
+        doc = json.loads(stdout or "{}")
+    except json.JSONDecodeError:
+        return []
+    if not isinstance(doc, dict):
+        return []
+    out: list[fdg.Finding] = []
+    for r in doc.get("resources", []) or []:
+        if not isinstance(r, dict):
+            continue
+        status = str(r.get("status", "")).lower()
+        if "invalid" not in status and "error" not in status:
+            continue
+        kind = r.get("kind") or "resource"
+        name = r.get("name") or ""
+        out.append(
+            fdg.Finding(
+                tool="kubeconform",
+                path=str(r.get("filename", "")),
+                line=None,
+                level="error",
+                rule=f"schema/{kind}",
+                message=f"{kind} {name}: {r.get('msg', 'schema validation failed')}".strip(),
+            )
+        )
+    return out
+
+
+def _resolve_mode(config: CIConfig) -> str:
+    """Resolve kubeconform's mode: ``blocking`` (default) / ``warn`` / ``disabled``."""
+    return resolve_cross_tool_mode(config, "kubeconform", "blocking")
+
+
+def run(
+    manifests: list[Path],
+    config: CIConfig,
+    *,
+    sarif_path: str | Path | None = None,
+) -> int:
+    """Schema-validate ``manifests`` (rendered + plain). Returns exit code.
+
+    0 = valid / skipped-only / disabled / no manifests; 1 = a blocking gate hit
+    an invalid manifest, or the tool is required-but-missing in CI.
+    """
+    mode = _resolve_mode(config)
+    if mode == "disabled":
+        info("  kubeconform: disabled")
+        return 0
+    if not manifests:
+        info("  kubeconform: no manifests to validate - skipping")
+        return 0
+
+    exe = _install_kubeconform()
+    if not exe:
+        if mode == "blocking" and is_ci():
+            error(missing_tool_notice("kubeconform"))
+            return 1
+        warn(missing_tool_notice("kubeconform"))
+        return 0
+
+    cmd = [exe, "-output", "json", "-summary", "-ignore-missing-schemas"]
+    for loc in _schema_locations(config):
+        cmd += ["-schema-location", loc]
+    cmd += [str(p) for p in manifests]
+
+    info(f"  kubeconform: validating {len(manifests)} manifest file(s)...")
+    try:
+        result = run_cmd(cmd, check=False, capture=True)
+    except OSError as exc:
+        warn(f"  kubeconform could not be run ({exc})")
+        if mode == "blocking" and is_ci():
+            error("  kubeconform could not complete - failing the gate")
+            return 1
+        return 0
+    found = _parse(result.stdout)
+
+    # kubeconform exits 0 valid / 1 invalid (parsed into findings) / other on
+    # error. Non-zero with nothing parsed = a tool error (unreadable input, bad
+    # schema location), NOT "all valid" - never score a broken gate green.
+    if result.returncode != 0 and not found:
+        warn(
+            f"  kubeconform exited {result.returncode} with no parseable output - tool error, not a clean pass"
+        )
+        if mode == "blocking" and is_ci():
+            error("  kubeconform could not complete - failing the gate")
+            return 1
+        return 0
+
+    dropped = fdg.surface("kubeconform", found, sarif_path=sarif_path)
+    if dropped:
+        info(f"  kubeconform: +{dropped} more finding(s) in the job summary")
+
+    if not found:
+        success("  kubeconform: all manifests valid (unknown CRDs skipped)")
+        return 0
+    if mode == "blocking":
+        error(f"  kubeconform: {len(found)} invalid manifest(s) must be fixed")
+        return 1
+    warn(f"  kubeconform: {len(found)} invalid manifest(s) (non-blocking)")
+    return 0

--- a/src/hyperi_ci/quality/lint_manifests.py
+++ b/src/hyperi_ci/quality/lint_manifests.py
@@ -1,0 +1,112 @@
+# Project:   HyperI CI
+# File:      src/hyperi_ci/quality/lint_manifests.py
+# Purpose:   Orchestrate the k8s + IaC linting dimension (Path B)
+#
+# License:   BUSL-1.1 - HYPERI PTY LIMITED
+# Copyright: (c) 2026 HYPERI PTY LIMITED
+"""Orchestrate k8s + IaC linting for a gitops / infra repo (Path B).
+
+This is what the ``hyperi-ci lint-manifests <dir>`` verb runs. It is the
+entry point for GitHub-Actions-native gitops repos (dfe-infra has no
+``.hyperi-ci.yaml`` and no language pipeline), so their existing workflows can
+call one command instead of adopting the whole hyperi-ci pipeline.
+
+Pipeline:
+
+1. discover Helm charts + plain (already-rendered) manifests, pruning
+   ``.worktrees`` duplicate trees and chart internals;
+2. ``helm template`` the charts (kubeconform needs rendered manifests);
+3. **kubeconform** - schema-validation GATE over rendered charts + plain
+   manifests (its exit code is the verb's exit code);
+4. **kube-linter** - best-practice ADVISORY over charts + manifests (kube-linter
+   templates Helm itself);
+5. **Checkov** - IaC security ADVISORY over the whole tree (k8s/helm/kustomize/
+   terraform).
+
+Only kubeconform gates; the advisories always run (even when the gate fails,
+so their findings still surface) and never change the exit code.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+from hyperi_ci.common import error, get_exclude_dirs, group, info, is_ci, warn
+from hyperi_ci.config import CIConfig
+from hyperi_ci.languages.quality_common import resolve_cross_tool_mode
+from hyperi_ci.quality import checkov, kube_linter, kubeconform, render
+from hyperi_ci.quality.targets import discover_helm_charts, discover_manifests
+
+
+def run(
+    root: Path | str, config: CIConfig, *, sarif_path: str | Path | None = None
+) -> int:
+    """Lint every chart / manifest / IaC file under ``root``.
+
+    Returns non-zero when a GATE fails: kubeconform (a schema-invalid manifest)
+    OR a Checkov set to ``blocking``. kube-linter is always advisory and never
+    affects the exit code; Checkov is advisory by DEFAULT (``warn``) and only
+    gates when a repo has escalated it. All tools always RUN (even after a gate
+    fails) so their findings still surface.
+    """
+    root = Path(root)
+    exclude = get_exclude_dirs(config._raw)
+    charts = discover_helm_charts(root, exclude_dirs=exclude)
+    manifests = discover_manifests(root, exclude_dirs=exclude)
+
+    if not charts and not manifests:
+        info(f"lint-manifests: no Helm charts or k8s manifests under {root} - skipping")
+        # Still run Checkov: a repo may be pure IaC (.tf) with no k8s at all.
+        with group("checkov IaC security advisory"):
+            return _run_checkov(root, config, sarif_path)
+
+    info(
+        f"lint-manifests: {len(charts)} chart(s), {len(manifests)} plain manifest(s) under {root}"
+    )
+
+    gate_rc = 0
+    with tempfile.TemporaryDirectory(prefix="hyperi-lint-manifests-") as tmp:
+        rendered: list[Path] = []
+        if charts:
+            if render.helm_available():
+                with group("Render Helm charts"):
+                    rendered = render.render_charts(charts, Path(tmp) / "rendered")
+            else:
+                warn(
+                    "  helm not on PATH - charts will NOT be schema-validated "
+                    "(kube-linter/checkov still cover them). Install helm for the gate."
+                )
+        # A chart that did not render - helm absent, OR a `helm template` failure
+        # for that chart - was NOT schema-validated. A blocking gate must not
+        # pass green having skipped charts (design principle 3, No silent skips).
+        unrendered = len(charts) - len(rendered)
+        with group("kubeconform schema validation (gate)"):
+            gate_rc = kubeconform.run(
+                rendered + manifests, config, sarif_path=sarif_path
+            )
+        if (
+            unrendered
+            and is_ci()
+            and resolve_cross_tool_mode(config, "kubeconform", "blocking") == "blocking"
+        ):
+            error(
+                f"  kubeconform: {unrendered} of {len(charts)} chart(s) could not be "
+                "rendered/validated and the gate is blocking - failing rather than "
+                "pass unchecked charts"
+            )
+            gate_rc = gate_rc or 1
+
+    with group("kube-linter best-practice advisory"):
+        kube_linter.run([*charts, *manifests], config, sarif_path=sarif_path)
+
+    with group("checkov IaC security advisory"):
+        checkov_rc = _run_checkov(root, config, sarif_path)
+
+    # A failing gate wins: kubeconform OR a blocking Checkov fails the verb.
+    return gate_rc or checkov_rc
+
+
+def _run_checkov(root: Path, config: CIConfig, sarif_path: str | Path | None) -> int:
+    """Run the Checkov advisory (kept separate so the no-manifests path reuses it)."""
+    return checkov.run(root, config, sarif_path=sarif_path)

--- a/src/hyperi_ci/quality/render.py
+++ b/src/hyperi_ci/quality/render.py
@@ -1,0 +1,73 @@
+# Project:   HyperI CI
+# File:      src/hyperi_ci/quality/render.py
+# Purpose:   Render Helm charts to plain manifests for schema validation
+#
+# License:   BUSL-1.1 - HYPERI PTY LIMITED
+# Copyright: (c) 2026 HYPERI PTY LIMITED
+"""Render Helm charts to plain manifests.
+
+kubeconform validates RENDERED manifests, not Go templates, so a chart must be
+``helm template``-d first. kube-linter templates Helm itself, so this is only
+for the kubeconform gate. dfe-infra's charts vendor their ``dfe-common``
+dependency as a committed ``.tgz`` under ``charts/`` with a ``Chart.lock``, so
+``helm dependency build`` resolves offline from what is already in the repo.
+
+Best-effort by design: a chart that fails to render (missing values, a bad
+dependency) is warned about and skipped rather than aborting the whole lint -
+the caller decides whether an unrenderable chart is fatal.
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+from pathlib import Path
+
+from hyperi_ci.common import info, run_cmd, warn
+
+
+def _release_name(chart: Path) -> str:
+    """A valid Helm release name derived from the chart dir.
+
+    Helm release names must be lowercase RFC1123-ish (``[a-z0-9-]``, start
+    alnum, <=53 chars). The chart DIRECTORY basename is not constrained that way
+    - a ``Chart/`` (capital) or ``my_chart/`` (underscore) dir makes
+    ``helm template`` fail with "invalid release name", which would silently
+    skip the chart and let the schema gate pass green having validated nothing
+    (a "No silent skips" violation). The release name is irrelevant to schema
+    validation, so sanitise the basename to something always-valid.
+    """
+    name = re.sub(r"[^a-z0-9-]", "-", chart.name.lower()).strip("-")
+    return (name or "chart")[:53]
+
+
+def helm_available() -> bool:
+    """True when the ``helm`` binary is on PATH."""
+    return shutil.which("helm") is not None
+
+
+def render_charts(charts: list[Path], out_dir: Path) -> list[Path]:
+    """Render each chart to ``out_dir/<chart>.rendered.yaml``; return the paths.
+
+    Runs ``helm dependency build`` (best-effort - many charts have no deps) then
+    ``helm template``. A chart that will not render is warned and skipped.
+    """
+    out_dir.mkdir(parents=True, exist_ok=True)
+    rendered: list[Path] = []
+    for chart in charts:
+        # dependency build is best-effort: charts with no dependencies exit
+        # non-zero on some helm versions, which must not abort the render.
+        run_cmd(["helm", "dependency", "build", str(chart)], check=False, capture=True)
+        result = run_cmd(
+            ["helm", "template", _release_name(chart), str(chart)],
+            check=False,
+            capture=True,
+        )
+        if result.returncode != 0:
+            warn(f"  render: helm template failed for {chart.name} - skipping")
+            continue
+        dest = out_dir / f"{chart.name}.rendered.yaml"
+        dest.write_text(result.stdout, encoding="utf-8", newline="\n")
+        rendered.append(dest)
+    info(f"  render: {len(rendered)}/{len(charts)} chart(s) templated")
+    return rendered

--- a/src/hyperi_ci/quality/targets.py
+++ b/src/hyperi_ci/quality/targets.py
@@ -1,0 +1,186 @@
+# Project:   HyperI CI
+# File:      src/hyperi_ci/quality/targets.py
+# Purpose:   Discover lint targets (Dockerfiles, k8s manifests) on disk
+#
+# License:   BUSL-1.1 - HYPERI PTY LIMITED
+# Copyright: (c) 2026 HYPERI PTY LIMITED
+"""Discover the files a linting tool should scan.
+
+gitleaks and semgrep scan the whole tree; the container / k8s linters need an
+explicit target list (hadolint takes files, kubeconform takes rendered
+manifests). Keeping discovery here means one place decides what counts as a
+Dockerfile / manifest and one place prunes the dirs nobody should lint (`.git`,
+`.worktrees` duplicate checkouts, vendored deps).
+
+Auto-detect + clean skip: a repo with no Dockerfile just yields ``[]`` and the
+tool info-skips - no opt-out config needed for a repo that has no target.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterable
+from pathlib import Path
+
+import yaml
+
+# Always pruned, regardless of config: VCS internals, worktree duplicate trees
+# (dfe-infra keeps two full checkouts under .worktrees/ - scanning them doubles
+# every finding), scratch, and the usual vendored-dependency sinks.
+_ALWAYS_PRUNE = {
+    ".git",
+    ".worktrees",
+    ".tmp",
+    ".hyperi-ai",
+    "node_modules",
+    "target",
+    "vendor",
+    ".venv",
+    "venv",
+    ".mypy_cache",
+    ".ruff_cache",
+    "__pycache__",
+}
+
+
+def _is_dockerfile(name: str) -> bool:
+    """Match Dockerfile / Containerfile and their .suffix / prefix. forms.
+
+    Matches ``Dockerfile``, ``Dockerfile.<x>``, ``<x>.Dockerfile`` and the
+    ``Containerfile`` equivalents. Deliberately does NOT match
+    ``.dockerignore`` (it starts with a dot, not ``Dockerfile.``).
+    """
+    for base in ("Dockerfile", "Containerfile"):
+        if name == base or name.startswith(f"{base}.") or name.endswith(f".{base}"):
+            return True
+    return False
+
+
+def discover_dockerfiles(
+    root: Path | str, *, exclude_dirs: Iterable[str] = ()
+) -> list[Path]:
+    """Return every Dockerfile/Containerfile under ``root``, pruned + sorted.
+
+    ``exclude_dirs`` (typically ``get_exclude_dirs(config)``) is added to the
+    always-pruned set. Paths are returned sorted for deterministic output.
+    """
+    root = Path(root)
+    prune = _ALWAYS_PRUNE | {str(d).strip("/") for d in exclude_dirs if d}
+    found: list[Path] = []
+    for dirpath, dirnames, filenames in os.walk(root):
+        # Prune in place so os.walk does not descend into excluded dirs.
+        dirnames[:] = [d for d in dirnames if d not in prune]
+        for fn in filenames:
+            if _is_dockerfile(fn):
+                found.append(Path(dirpath) / fn)
+    return sorted(found)
+
+
+def _prune(exclude_dirs: Iterable[str]) -> set[str]:
+    return _ALWAYS_PRUNE | {str(d).strip("/") for d in exclude_dirs if d}
+
+
+def discover_helm_charts(
+    root: Path | str, *, exclude_dirs: Iterable[str] = ()
+) -> list[Path]:
+    """Return top-level Helm chart directories (dirs holding a ``Chart.yaml``).
+
+    Skips:
+
+    * ``type: library`` charts - they render nothing on their own, so linting
+      or schema-validating them is pointless (dfe-infra's ``dfe-common``).
+    * subcharts - a ``Chart.yaml`` nested under another chart's ``charts/`` dir
+      is a vendored dependency, rendered by its parent, not a target itself.
+
+    Pruned dirs (``.worktrees`` etc) never descend, so a duplicate worktree
+    checkout does not double every chart.
+    """
+    root = Path(root)
+    prune = _prune(exclude_dirs)
+    charts: list[Path] = []
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = [d for d in dirnames if d not in prune]
+        if "Chart.yaml" not in filenames:
+            continue
+        chart_dir = Path(dirpath)
+        # A chart inside another chart's charts/ dir is a subchart - skip it.
+        if (
+            chart_dir.parent.name == "charts"
+            and (chart_dir.parent.parent / "Chart.yaml").exists()
+        ):
+            continue
+        if _is_library_chart(chart_dir / "Chart.yaml"):
+            continue
+        charts.append(chart_dir)
+    return sorted(charts)
+
+
+def _is_library_chart(chart_yaml: Path) -> bool:
+    """True when Chart.yaml declares ``type: library`` (renders nothing)."""
+    try:
+        data = yaml.safe_load(chart_yaml.read_text(encoding="utf-8"))
+    except (OSError, yaml.YAMLError):
+        return False
+    return isinstance(data, dict) and str(data.get("type", "")).lower() == "library"
+
+
+def _looks_like_manifest(path: Path) -> bool:
+    """True when any YAML doc in ``path`` has both ``apiVersion`` and ``kind``.
+
+    This is what separates a real k8s manifest (Deployment, an Argo CR, ...)
+    from a Helm ``values.yaml``, a ``Chart.yaml`` (has apiVersion but no kind),
+    or arbitrary config YAML - so kubeconform is fed manifests, not values
+    files it would reject as "missing kind". Helm TEMPLATE files (``{{ }}``)
+    are not valid YAML and fail the parse, so they are excluded here and get
+    rendered instead.
+    """
+    try:
+        docs = list(yaml.safe_load_all(path.read_text(encoding="utf-8")))
+    except (OSError, yaml.YAMLError):
+        return False
+    return any(isinstance(d, dict) and "apiVersion" in d and "kind" in d for d in docs)
+
+
+def _inside_chart(dirpath: Path, root: Path) -> bool:
+    """True when ``dirpath`` is at or under a Helm chart (an ancestor Chart.yaml).
+
+    Chart content (``templates/`` Go-templates, ``values.yaml``, ``Chart.yaml``)
+    is handled by :func:`discover_helm_charts` + ``helm template``, so it must
+    not also be picked up as a plain manifest - a chart template can happen to
+    parse as YAML, so the ``apiVersion``+``kind`` heuristic alone is not enough.
+    """
+    d = dirpath
+    while True:
+        if (d / "Chart.yaml").exists():
+            return True
+        if d == root or d.parent == d:
+            return False
+        d = d.parent
+
+
+def discover_manifests(
+    root: Path | str, *, exclude_dirs: Iterable[str] = ()
+) -> list[Path]:
+    """Return plain (already-rendered) k8s manifest YAML files under ``root``.
+
+    A file counts only if it holds at least one ``apiVersion``+``kind`` doc
+    (:func:`_looks_like_manifest`) AND is not inside a Helm chart
+    (:func:`_inside_chart`) - chart content is rendered separately. This yields
+    the loose manifests (Argo CRs, plain Deployments) that need direct schema
+    validation. Pruned dirs never descend.
+    """
+    root = Path(root)
+    prune = _prune(exclude_dirs)
+    out: list[Path] = []
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = [d for d in dirnames if d not in prune]
+        here = Path(dirpath)
+        if _inside_chart(here, root):
+            continue
+        for fn in filenames:
+            if not fn.endswith((".yaml", ".yml")):
+                continue
+            p = here / fn
+            if _looks_like_manifest(p):
+                out.append(p)
+    return sorted(out)

--- a/src/hyperi_ci/tools.py
+++ b/src/hyperi_ci/tools.py
@@ -83,6 +83,62 @@ _REGISTRY: dict[str, ToolInfo] = {
         ),
         url="https://semgrep.dev/docs/getting-started/",
     ),
+    "hadolint": ToolInfo(
+        name="hadolint",
+        purpose="Dockerfile linting gate (lints the shell inside RUN via ShellCheck)",
+        # Single static binary. brew on macOS; a release binary elsewhere. On
+        # Linux CI hyperi-ci auto-installs the pinned release, so this notice is
+        # for local dev.
+        install=(
+            "brew install hadolint",
+            "download a release binary: https://github.com/hadolint/hadolint/releases/latest",
+        ),
+        url="https://github.com/hadolint/hadolint#install",
+    ),
+    "droast": ToolInfo(
+        name="droast",
+        purpose="Dockerfile advisory - cache ordering / .dockerignore / npm ci (DF070/DF033/DF031)",
+        # Advisory-only, never auto-installed. cargo binstall fetches a prebuilt
+        # binary; `cargo install` builds from source (slower, last resort).
+        install=(
+            "cargo binstall dockerfile-roast",
+            "cargo install dockerfile-roast  # from source - slowest",
+            "download a release binary: https://github.com/immanuwell/dockerfile-roast/releases/latest",
+        ),
+        url="https://github.com/immanuwell/dockerfile-roast",
+    ),
+    "kubeconform": ToolInfo(
+        name="kubeconform",
+        purpose="Kubernetes manifest schema validation gate",
+        # Single static Go binary. On Linux CI hyperi-ci auto-installs the
+        # pinned release; this notice is for local dev.
+        install=(
+            "brew install kubeconform",
+            "go install github.com/yannh/kubeconform/cmd/kubeconform@latest",
+        ),
+        url="https://github.com/yannh/kubeconform#installation",
+    ),
+    "kube-linter": ToolInfo(
+        name="kube-linter",
+        purpose="Kubernetes best-practice advisory (production-readiness / security)",
+        install=(
+            "brew install kube-linter",
+            "go install golang.stackrox.io/kube-linter/cmd/kube-linter@latest",
+        ),
+        url="https://docs.kubelinter.io/#/configuring-kubelinter",
+    ),
+    "checkov": ToolInfo(
+        name="checkov",
+        purpose="IaC security scanning (k8s / helm / kustomize / terraform / opentofu)",
+        # astral first: uv is already a hard dependency, so `uvx` needs nothing
+        # new (same rationale as semgrep).
+        install=(
+            "uvx checkov --version",
+            "uv tool install checkov",
+            "pip install checkov",
+        ),
+        url="https://www.checkov.io/2.Basics/Installing%20Checkov.html",
+    ),
     "osv-scanner": ToolInfo(
         name="osv-scanner",
         purpose="dependency vulnerability scanning (OSV)",

--- a/tests/unit/test_checkov.py
+++ b/tests/unit/test_checkov.py
@@ -1,0 +1,139 @@
+# Project:   HyperI CI
+# File:      tests/unit/test_checkov.py
+# Purpose:   Tests for the Checkov IaC security advisory
+#
+# License:   BUSL-1.1 - HYPERI PTY LIMITED
+# Copyright: (c) 2026 HYPERI PTY LIMITED
+"""Tests for hyperi_ci.quality.checkov."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from hyperi_ci.config import CIConfig
+from hyperi_ci.quality import checkov
+
+_SKIP = "HYPERCI_QUALITY_SKIP"
+
+_SARIF = json.dumps(
+    {
+        "runs": [
+            {
+                "tool": {"driver": {"name": "checkov", "rules": []}},
+                "results": [
+                    {
+                        "ruleId": "CKV_K8S_20",
+                        "level": "error",
+                        "message": {"text": "containers should not run as root"},
+                        "locations": [
+                            {
+                                "physicalLocation": {
+                                    "artifactLocation": {"uri": "chart/deploy.yaml"}
+                                }
+                            }
+                        ],
+                    }
+                ],
+            }
+        ]
+    }
+)
+
+
+def _cfg(raw: dict | None = None) -> CIConfig:
+    return CIConfig(_raw=raw or {})
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(_SKIP, raising=False)
+    monkeypatch.delenv("HYPERCI_QUALITY_STRICT", raising=False)
+
+
+def _stub(
+    monkeypatch: pytest.MonkeyPatch, sarif_text: str, *, has_tool: bool = True
+) -> dict:
+    """Stub the checkov invocation; write the sarif the module will read back."""
+    captured: dict = {}
+    monkeypatch.setattr(checkov, "_base_cmd", lambda: ["checkov"] if has_tool else None)
+
+    def _run(cmd, **kw):  # noqa: ANN001, ANN003
+        captured["cmd"] = cmd
+        # Emulate checkov writing results_sarif.sarif into --output-file-path.
+        out_idx = cmd.index("--output-file-path") + 1
+        (Path(cmd[out_idx]) / "results_sarif.sarif").write_text(
+            sarif_text, encoding="utf-8"
+        )
+        return SimpleNamespace(stdout="", returncode=0)
+
+    monkeypatch.setattr(checkov, "run_cmd", _run)
+    return captured
+
+
+class TestRun:
+    def test_disabled(self, tmp_path: Path) -> None:
+        assert checkov.run(tmp_path, _cfg({"quality": {"checkov": "disabled"}})) == 0
+
+    def test_missing_tool_warn_skips(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _stub(monkeypatch, "", has_tool=False)
+        assert checkov.run(tmp_path, _cfg()) == 0
+
+    def test_warn_default_never_fails(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _stub(monkeypatch, _SARIF)
+        assert checkov.run(tmp_path, _cfg()) == 0
+
+    def test_blocking_fails_on_findings(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _stub(monkeypatch, _SARIF)
+        assert checkov.run(tmp_path, _cfg({"quality": {"checkov": "blocking"}})) == 1
+
+    def test_clean_passes(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _stub(
+            monkeypatch, json.dumps({"runs": [{"tool": {"driver": {}}, "results": []}]})
+        )
+        assert checkov.run(tmp_path, _cfg({"quality": {"checkov": "blocking"}})) == 0
+
+    def test_default_frameworks_and_skips(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        captured = _stub(monkeypatch, _SARIF)
+        checkov.run(tmp_path, _cfg())
+        cmd = captured["cmd"]
+        assert "kubernetes" in cmd and "terraform" in cmd
+        assert "--soft-fail" in cmd
+        # Default worktree skip-path present.
+        assert any(".worktrees" in c for c in cmd)
+
+    def test_config_skip_checks(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        captured = _stub(monkeypatch, _SARIF)
+        checkov.run(tmp_path, _cfg({"quality": {"checkov": {"skip": ["CKV_K8S_1"]}}}))
+        cmd = captured["cmd"]
+        assert "--skip-check" in cmd and "CKV_K8S_1" in cmd
+
+    def test_force_skip_disables(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(_SKIP, "checkov")
+        assert checkov.run(tmp_path, _cfg()) == 0
+
+    def test_strict_upgrades_warn_to_blocking(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # --strict (HYPERCI_QUALITY_STRICT) escalates the default `warn` Checkov
+        # to blocking, so a finding now fails.
+        monkeypatch.setenv("HYPERCI_QUALITY_STRICT", "1")
+        _stub(monkeypatch, _SARIF)
+        assert checkov.run(tmp_path, _cfg()) == 1

--- a/tests/unit/test_droast.py
+++ b/tests/unit/test_droast.py
@@ -1,0 +1,139 @@
+# Project:   HyperI CI
+# File:      tests/unit/test_droast.py
+# Purpose:   Tests for the droast Dockerfile advisory
+#
+# License:   BUSL-1.1 - HYPERI PTY LIMITED
+# Copyright: (c) 2026 HYPERI PTY LIMITED
+"""Tests for hyperi_ci.quality.droast - advisory only, never gates."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from hyperi_ci.config import CIConfig
+from hyperi_ci.quality import droast
+
+_SARIF = json.dumps(
+    {
+        "version": "2.1.0",
+        "runs": [
+            {
+                "tool": {
+                    "driver": {
+                        "name": "droast",
+                        "rules": [{"id": "DF070", "helpUri": "https://x/DF070"}],
+                    }
+                },
+                "results": [
+                    {
+                        "ruleId": "DF070",
+                        "level": "warning",
+                        "message": {"text": "COPY . . before install busts the cache"},
+                        "locations": [
+                            {
+                                "physicalLocation": {
+                                    "artifactLocation": {"uri": "Dockerfile"},
+                                    "region": {"startLine": 4},
+                                }
+                            }
+                        ],
+                    }
+                ],
+            }
+        ],
+    }
+)
+
+
+def _cfg(raw: dict | None = None) -> CIConfig:
+    return CIConfig(_raw=raw or {})
+
+
+def _stub(
+    monkeypatch: pytest.MonkeyPatch, stdout: str, *, exe: str | None = "/usr/bin/droast"
+) -> None:
+    monkeypatch.setattr(droast, "find_tool", lambda *a, **k: exe)
+    monkeypatch.setattr(
+        droast, "run_cmd", lambda *a, **k: SimpleNamespace(stdout=stdout, returncode=0)
+    )
+
+
+class TestRun:
+    def test_disabled_short_circuits(self) -> None:
+        assert droast.run(_cfg({"quality": {"droast": "disabled"}})) == 0
+
+    def test_no_dockerfile_skips(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        assert droast.run(_cfg()) == 0
+
+    def test_missing_tool_info_skips(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "Dockerfile").write_text("FROM x\n", encoding="utf-8")
+        _stub(monkeypatch, "", exe=None)
+        assert droast.run(_cfg()) == 0
+
+    def test_findings_never_fail(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "Dockerfile").write_text("FROM x\nCOPY . .\n", encoding="utf-8")
+        _stub(monkeypatch, _SARIF)
+        # Advisory: even with findings it returns 0.
+        assert droast.run(_cfg()) == 0
+
+    def test_uses_shipped_config_when_no_repo_toml(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "Dockerfile").write_text("FROM x\n", encoding="utf-8")
+        captured: dict = {}
+
+        def _capture(cmd, **kw):  # noqa: ANN001, ANN003
+            captured["cmd"] = cmd
+            return SimpleNamespace(stdout="", returncode=0)
+
+        monkeypatch.setattr(droast, "find_tool", lambda *a, **k: "/usr/bin/droast")
+        monkeypatch.setattr(droast, "run_cmd", _capture)
+        droast.run(_cfg())
+        assert "--config" in captured["cmd"]
+
+    def test_repo_toml_wins(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "Dockerfile").write_text("FROM x\n", encoding="utf-8")
+        (tmp_path / "droast.toml").write_text(
+            "min-severity = 'info'\n", encoding="utf-8"
+        )
+        captured: dict = {}
+
+        def _capture(cmd, **kw):  # noqa: ANN001, ANN003
+            captured["cmd"] = cmd
+            return SimpleNamespace(stdout="", returncode=0)
+
+        monkeypatch.setattr(droast, "find_tool", lambda *a, **k: "/usr/bin/droast")
+        monkeypatch.setattr(droast, "run_cmd", _capture)
+        droast.run(_cfg())
+        # Repo's own droast.toml is auto-discovered; we must NOT force --config.
+        assert "--config" not in captured["cmd"]
+
+    def test_oserror_is_swallowed(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "Dockerfile").write_text("FROM x\n", encoding="utf-8")
+
+        def _boom(*a, **k):  # noqa: ANN002, ANN003
+            raise OSError("exec failed")
+
+        monkeypatch.setattr(droast, "find_tool", lambda *a, **k: "/usr/bin/droast")
+        monkeypatch.setattr(droast, "run_cmd", _boom)
+        assert droast.run(_cfg()) == 0

--- a/tests/unit/test_findings.py
+++ b/tests/unit/test_findings.py
@@ -1,0 +1,323 @@
+# Project:   HyperI CI
+# File:      tests/unit/test_findings.py
+# Purpose:   Tests for the shared finding surface (annotations/summary/SARIF)
+#
+# License:   BUSL-1.1 - HYPERI PTY LIMITED
+# Copyright: (c) 2026 HYPERI PTY LIMITED
+"""Tests for hyperi_ci.quality.findings - the shared linting surface.
+
+Covers the load-bearing bits: severity folding, the step-global annotation
+budget (cap + errors-first + overflow count + no-op outside Actions), the job
+summary table, and the multi-run SARIF writer.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from hyperi_ci.quality import findings
+from hyperi_ci.quality.findings import Finding
+
+
+@pytest.fixture(autouse=True)
+def _fresh_budget() -> None:
+    findings.reset_annotation_budget()
+
+
+def _f(
+    level: str, rule: str = "R1", path: str = "Dockerfile", line: int | None = 1
+) -> Finding:
+    return Finding(
+        tool="hadolint", path=path, line=line, level=level, rule=rule, message="m"
+    )
+
+
+class TestNormaliseLevel:
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            ("error", "error"),
+            ("ERROR", "error"),
+            ("warning", "warning"),
+            ("warn", "warning"),
+            ("info", "notice"),
+            ("style", "notice"),
+            ("note", "notice"),
+            ("something-odd", "warning"),  # unknown -> safe middle
+        ],
+    )
+    def test_folds(self, raw: str, expected: str) -> None:
+        assert findings.normalise_level(raw) == expected
+
+
+class TestEmitAnnotations:
+    def test_noop_outside_actions(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
+        dropped = findings.emit_annotations([_f("error")])
+        assert dropped == 0
+        assert capsys.readouterr().out == ""
+
+    def test_emits_workflow_command(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        monkeypatch.setenv("GITHUB_ACTIONS", "true")
+        findings.emit_annotations(
+            [_f("error", rule="DL3008", path="Dockerfile", line=7)]
+        )
+        out = capsys.readouterr().out
+        assert "::error " in out
+        assert "file=Dockerfile" in out
+        assert "line=7" in out
+        assert "DL3008" in out
+
+    def test_budget_cap_and_overflow_count(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        monkeypatch.setenv("GITHUB_ACTIONS", "true")
+        # 12 warnings, cap is 10 -> 2 overflow, 10 printed.
+        dropped = findings.emit_annotations([_f("warning") for _ in range(12)])
+        assert dropped == 2
+        assert capsys.readouterr().out.count("::warning ") == 10
+
+    def test_budget_is_shared_across_calls(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        monkeypatch.setenv("GITHUB_ACTIONS", "true")
+        findings.emit_annotations([_f("error") for _ in range(6)])
+        # Second tool in the same step draws from the same pool: 4 left.
+        dropped = findings.emit_annotations([_f("error") for _ in range(6)])
+        assert dropped == 2
+
+    def test_errors_first(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        monkeypatch.setenv("GITHUB_ACTIONS", "true")
+        # One error last in the list still annotates before warnings are considered.
+        findings.reset_annotation_budget()
+        findings.emit_annotations([_f("warning"), _f("warning"), _f("error", rule="E")])
+        lines = [
+            ln for ln in capsys.readouterr().out.splitlines() if ln.startswith("::")
+        ]
+        assert lines[0].startswith("::error ")
+
+    def test_newlines_encoded(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        monkeypatch.setenv("GITHUB_ACTIONS", "true")
+        f = Finding("t", "f", 1, "error", "R", "line one\nline two")
+        findings.emit_annotations([f])
+        out = capsys.readouterr().out
+        assert "%0A" in out
+        assert "\nline two" not in out.split("::error", 1)[1]
+
+
+class TestJobSummary:
+    def test_writes_table(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        summary = tmp_path / "summary.md"
+        monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary))
+        findings.append_job_summary("hadolint", [_f("warning", rule="DL3008")])
+        text = summary.read_text(encoding="utf-8")
+        assert "hadolint: 1 finding(s)" in text
+        assert "DL3008" in text
+        assert "| Severity | Rule | Location | Message |" in text
+
+    def test_noop_when_unset(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("GITHUB_STEP_SUMMARY", raising=False)
+        # Must not raise.
+        findings.append_job_summary("hadolint", [_f("warning")])
+
+    def test_pipe_in_message_escaped(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        summary = tmp_path / "s.md"
+        monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary))
+        f = Finding("t", "f", 1, "warning", "R", "a | b")
+        findings.append_job_summary("t", [f])
+        assert "a \\| b" in summary.read_text(encoding="utf-8")
+
+
+class TestSarif:
+    def test_valid_single_run(self, tmp_path: Path) -> None:
+        out = tmp_path / "r.sarif"
+        findings.write_sarif("hadolint", [_f("error", rule="DL4006")], out)
+        doc = json.loads(out.read_text(encoding="utf-8"))
+        assert doc["version"] == "2.1.0"
+        assert len(doc["runs"]) == 1
+        run = doc["runs"][0]
+        assert run["tool"]["driver"]["name"] == "hadolint"
+        assert run["results"][0]["ruleId"] == "DL4006"
+        assert run["results"][0]["level"] == "error"
+
+    def test_appends_second_run(self, tmp_path: Path) -> None:
+        out = tmp_path / "r.sarif"
+        findings.write_sarif("hadolint", [_f("error")], out)
+        findings.write_sarif("kubeconform", [_f("error", path="deploy.yaml")], out)
+        doc = json.loads(out.read_text(encoding="utf-8"))
+        assert [r["tool"]["driver"]["name"] for r in doc["runs"]] == [
+            "hadolint",
+            "kubeconform",
+        ]
+
+    def test_notice_maps_to_note(self, tmp_path: Path) -> None:
+        out = tmp_path / "r.sarif"
+        findings.write_sarif("droast", [_f("notice", rule="DF033")], out)
+        doc = json.loads(out.read_text(encoding="utf-8"))
+        assert doc["runs"][0]["results"][0]["level"] == "note"
+
+    def test_corrupt_prior_file_starts_fresh(self, tmp_path: Path) -> None:
+        out = tmp_path / "r.sarif"
+        out.write_text("{ not json", encoding="utf-8")
+        findings.write_sarif("t", [_f("error")], out)
+        doc = json.loads(out.read_text(encoding="utf-8"))
+        assert len(doc["runs"]) == 1
+
+
+class TestParseSarif:
+    def test_extracts_finding(self) -> None:
+        text = json.dumps(
+            {
+                "runs": [
+                    {
+                        "tool": {
+                            "driver": {
+                                "name": "droast",
+                                "rules": [
+                                    {"id": "DF070", "helpUri": "https://x/DF070"}
+                                ],
+                            }
+                        },
+                        "results": [
+                            {
+                                "ruleId": "DF070",
+                                "level": "warning",
+                                "message": {"text": "cache buster"},
+                                "locations": [
+                                    {
+                                        "physicalLocation": {
+                                            "artifactLocation": {"uri": "Dockerfile"},
+                                            "region": {"startLine": 4},
+                                        }
+                                    }
+                                ],
+                            }
+                        ],
+                    }
+                ]
+            }
+        )
+        out = findings.parse_sarif(text, "droast")
+        assert len(out) == 1
+        f = out[0]
+        assert f.tool == "droast"
+        assert f.rule == "DF070"
+        assert f.level == "warning"
+        assert f.path == "Dockerfile"
+        assert f.line == 4
+        assert f.url == "https://x/DF070"
+
+    def test_note_folds_to_notice(self) -> None:
+        text = json.dumps(
+            {
+                "runs": [
+                    {
+                        "tool": {"driver": {}},
+                        "results": [
+                            {"ruleId": "R", "level": "note", "message": {"text": "m"}}
+                        ],
+                    }
+                ]
+            }
+        )
+        assert findings.parse_sarif(text, "t")[0].level == "notice"
+
+    def test_no_location(self) -> None:
+        text = json.dumps(
+            {
+                "runs": [
+                    {
+                        "tool": {"driver": {}},
+                        "results": [
+                            {"ruleId": "R", "level": "error", "message": {"text": "m"}}
+                        ],
+                    }
+                ]
+            }
+        )
+        f = findings.parse_sarif(text, "t")[0]
+        assert f.path == "" and f.line is None
+
+    def test_malformed_returns_empty(self) -> None:
+        assert findings.parse_sarif("not json", "t") == []
+        assert findings.parse_sarif("[]", "t") == []
+
+
+class TestSurface:
+    def test_returns_dropped_count(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("GITHUB_ACTIONS", "true")
+        # 12 warnings, cap 10 -> surface reports 2 dropped.
+        assert findings.surface("t", [_f("warning") for _ in range(12)]) == 2
+
+    def test_shared_budget_across_two_tools(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("GITHUB_ACTIONS", "true")
+        # Two tools in one process share the budget: 6 + 6 errors -> 2 overflow.
+        findings.surface("hadolint", [_f("error") for _ in range(6)])
+        assert findings.surface("droast", [_f("error") for _ in range(6)]) == 2
+
+    def test_writes_summary_and_sarif(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(tmp_path / "s.md"))
+        sarif = tmp_path / "out.sarif"
+        findings.surface("t", [_f("error")], sarif_path=sarif)
+        assert (tmp_path / "s.md").exists()
+        assert sarif.exists()
+
+    def test_summary_write_failure_does_not_raise(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        # Unwritable summary path (a directory) must not crash surfacing.
+        monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(tmp_path))
+        findings.append_job_summary("t", [_f("error")])  # no exception
+
+
+class TestAnnotationEscaping:
+    def test_property_delimiters_stripped(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        monkeypatch.setenv("GITHUB_ACTIONS", "true")
+        # A repo-controlled kind/filename with a comma / :: must not inject a
+        # second annotation property.
+        f = Finding(
+            "kubeconform", "a,line=99.yaml", 1, "error", "schema/Foo,line=7", "m"
+        )
+        findings.emit_annotations([f])
+        line = capsys.readouterr().out.strip()
+        # The injected commas are stripped, so "line=99"/"line=7" are inert text
+        # inside the file/title values, NOT new comma-delimited properties.
+        assert ",line=99" not in line
+        assert ",line=7" not in line
+        # The one real line property (from f.line=1) survives as a property.
+        assert "line=1::" in line
+
+
+class TestSummaryTruncation:
+    def test_truncates_over_cap(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        summary = tmp_path / "s.md"
+        monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary))
+        many = [
+            _f("warning", rule=f"R{i}") for i in range(findings._MAX_SUMMARY_ROWS + 5)
+        ]
+        findings.append_job_summary("t", many)
+        text = summary.read_text(encoding="utf-8")
+        assert "5 more findings truncated" in text

--- a/tests/unit/test_hadolint.py
+++ b/tests/unit/test_hadolint.py
@@ -1,0 +1,235 @@
+# Project:   HyperI CI
+# File:      tests/unit/test_hadolint.py
+# Purpose:   Tests for the hadolint Dockerfile gate
+#
+# License:   BUSL-1.1 - HYPERI PTY LIMITED
+# Copyright: (c) 2026 HYPERI PTY LIMITED
+"""Tests for hyperi_ci.quality.hadolint.
+
+The gate contract: parse hadolint's JSON, surface findings, and fail the stage
+only in ``blocking`` mode when an ERROR-severity finding exists - warning/info
+are surfaced but never fatal (the recon-confirmed near-silent gate).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from hyperi_ci.config import CIConfig
+from hyperi_ci.quality import hadolint
+
+_SKIP = "HYPERCI_QUALITY_SKIP"
+_STRICT = "HYPERCI_QUALITY_STRICT"
+
+
+def _cfg(raw: dict | None = None) -> CIConfig:
+    return CIConfig(_raw=raw or {})
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(_SKIP, raising=False)
+    monkeypatch.delenv(_STRICT, raising=False)
+
+
+def _stub_run(monkeypatch: pytest.MonkeyPatch, stdout: str) -> None:
+    monkeypatch.setattr(hadolint, "_install_hadolint", lambda: "/usr/bin/hadolint")
+    monkeypatch.setattr(
+        hadolint,
+        "run_cmd",
+        lambda *a, **k: SimpleNamespace(stdout=stdout, returncode=0),
+    )
+
+
+class TestParse:
+    def test_maps_fields_and_urls(self) -> None:
+        payload = json.dumps(
+            [
+                {
+                    "file": "Dockerfile",
+                    "line": 3,
+                    "level": "error",
+                    "code": "SC2086",
+                    "message": "quote",
+                },
+                {
+                    "file": "Dockerfile",
+                    "line": 5,
+                    "level": "warning",
+                    "code": "DL3008",
+                    "message": "pin",
+                },
+            ]
+        )
+        found = hadolint._parse(payload)
+        assert len(found) == 2
+        assert found[0].level == "error"
+        assert "shellcheck.net" in found[0].url
+        assert found[1].rule == "DL3008"
+        assert "hadolint/hadolint/wiki" in found[1].url
+
+    def test_blank_is_empty(self) -> None:
+        assert hadolint._parse("") == []
+        assert hadolint._parse("not json") == []
+
+
+class TestResolveMode:
+    def test_default_blocking(self) -> None:
+        assert hadolint._resolve_mode(_cfg()) == "blocking"
+
+    def test_disabled(self) -> None:
+        assert (
+            hadolint._resolve_mode(_cfg({"quality": {"hadolint": "disabled"}}))
+            == "disabled"
+        )
+
+    def test_skip_wins(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(_SKIP, "hadolint")
+        assert hadolint._resolve_mode(_cfg()) == "disabled"
+
+    def test_unknown_mode_falls_back_to_default(self) -> None:
+        # A typo like `block` must NOT silently disable the gate - it warns and
+        # falls back to the tool's default (blocking here), not advisory.
+        assert (
+            hadolint._resolve_mode(_cfg({"quality": {"hadolint": "block"}}))
+            == "blocking"
+        )
+
+
+class TestRun:
+    def test_disabled_short_circuits(self) -> None:
+        assert hadolint.run(_cfg({"quality": {"hadolint": "disabled"}})) == 0
+
+    def test_no_dockerfile_skips(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        assert hadolint.run(_cfg()) == 0
+
+    def test_blocking_fails_on_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "Dockerfile").write_text(
+            "FROM x\nRUN echo $UNQUOTED\n", encoding="utf-8"
+        )
+        _stub_run(
+            monkeypatch,
+            json.dumps(
+                [
+                    {
+                        "file": "Dockerfile",
+                        "line": 2,
+                        "level": "error",
+                        "code": "SC2086",
+                        "message": "q",
+                    }
+                ]
+            ),
+        )
+        assert hadolint.run(_cfg()) == 1
+
+    def test_blocking_passes_on_warnings_only(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # DL3008-style warnings must NOT fail a blocking gate (near-silent day one).
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "Dockerfile").write_text(
+            "FROM x\nRUN apt-get install y\n", encoding="utf-8"
+        )
+        _stub_run(
+            monkeypatch,
+            json.dumps(
+                [
+                    {
+                        "file": "Dockerfile",
+                        "line": 2,
+                        "level": "warning",
+                        "code": "DL3008",
+                        "message": "pin",
+                    }
+                ]
+            ),
+        )
+        assert hadolint.run(_cfg()) == 0
+
+    def test_warn_mode_never_fails(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "Dockerfile").write_text("FROM x\n", encoding="utf-8")
+        _stub_run(
+            monkeypatch,
+            json.dumps(
+                [
+                    {
+                        "file": "Dockerfile",
+                        "line": 1,
+                        "level": "error",
+                        "code": "SC2086",
+                        "message": "q",
+                    }
+                ]
+            ),
+        )
+        assert hadolint.run(_cfg({"quality": {"hadolint": "warn"}})) == 0
+
+    def test_clean_passes(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "Dockerfile").write_text("FROM x\n", encoding="utf-8")
+        _stub_run(monkeypatch, "[]")
+        assert hadolint.run(_cfg()) == 0
+
+    def test_missing_tool_blocks_in_ci(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "Dockerfile").write_text("FROM x\n", encoding="utf-8")
+        monkeypatch.setattr(hadolint, "_install_hadolint", lambda: None)
+        monkeypatch.setattr(hadolint, "is_ci", lambda: True)
+        assert hadolint.run(_cfg()) == 1
+
+    def test_missing_tool_warn_skips_locally(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "Dockerfile").write_text("FROM x\n", encoding="utf-8")
+        monkeypatch.setattr(hadolint, "_install_hadolint", lambda: None)
+        monkeypatch.setattr(hadolint, "is_ci", lambda: False)
+        assert hadolint.run(_cfg()) == 0
+
+    def test_tool_error_blocks_in_ci(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # --no-fail means non-zero exit + no parseable output = a TOOL error
+        # (corrupt binary), not a clean pass. A blocking gate must not go green.
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "Dockerfile").write_text("FROM x\n", encoding="utf-8")
+        monkeypatch.setattr(hadolint, "_install_hadolint", lambda: "/usr/bin/hadolint")
+        monkeypatch.setattr(
+            hadolint,
+            "run_cmd",
+            lambda *a, **k: SimpleNamespace(stdout="", returncode=127),
+        )
+        monkeypatch.setattr(hadolint, "is_ci", lambda: True)
+        assert hadolint.run(_cfg()) == 1
+
+    def test_exec_oserror_does_not_crash(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "Dockerfile").write_text("FROM x\n", encoding="utf-8")
+        monkeypatch.setattr(hadolint, "_install_hadolint", lambda: "/usr/bin/hadolint")
+
+        def _boom(*a, **k):  # noqa: ANN002, ANN003
+            raise OSError("no exec bit")
+
+        monkeypatch.setattr(hadolint, "run_cmd", _boom)
+        monkeypatch.setattr(hadolint, "is_ci", lambda: False)
+        assert hadolint.run(_cfg()) == 0  # handled, not a traceback

--- a/tests/unit/test_install.py
+++ b/tests/unit/test_install.py
@@ -1,0 +1,111 @@
+# Project:   HyperI CI
+# File:      tests/unit/test_install.py
+# Purpose:   Tests for the shared CI-binary installer
+#
+# License:   BUSL-1.1 - HYPERI PTY LIMITED
+# Copyright: (c) 2026 HYPERI PTY LIMITED
+"""Tests for hyperi_ci.quality.install.install_ci_binary (no real downloads)."""
+
+from __future__ import annotations
+
+import io
+import subprocess
+import tarfile
+from types import SimpleNamespace
+
+import pytest
+
+from hyperi_ci.quality import install
+
+
+def _make_targz(member_name: str, data: bytes = b"BINARY") -> bytes:
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tf:
+        info = tarfile.TarInfo(name=member_name)
+        info.size = len(data)
+        tf.addfile(info, io.BytesIO(data))
+    return buf.getvalue()
+
+
+class TestInstallCiBinary:
+    def test_returns_existing_path(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(install.shutil, "which", lambda n: "/usr/bin/hadolint")
+        assert install.install_ci_binary("hadolint", "http://x") == "/usr/bin/hadolint"
+
+    def test_none_off_ci(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(install.shutil, "which", lambda n: None)
+        monkeypatch.setattr(install, "is_ci", lambda: False)
+        assert install.install_ci_binary("hadolint", "http://x") is None
+
+    def test_none_off_linux(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(install.shutil, "which", lambda n: None)
+        monkeypatch.setattr(install, "is_ci", lambda: True)
+        monkeypatch.setattr(install.sys, "platform", "darwin")
+        assert install.install_ci_binary("hadolint", "http://x") is None
+
+
+class TestInstallBody:
+    """The download/extract/install core - Linux CI, all subprocess mocked."""
+
+    def _wire(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        *,
+        curl_stdout: bytes = b"BIN",
+        curl_rc: int = 0,
+        sudo_raises: bool = False,
+    ) -> dict:
+        monkeypatch.setattr(install, "is_ci", lambda: True)
+        monkeypatch.setattr(install.sys, "platform", "linux")
+        state: dict = {"installed": False, "cmds": []}
+        monkeypatch.setattr(
+            install.shutil,
+            "which",
+            lambda n: "/usr/local/bin/tool" if state["installed"] else None,
+        )
+
+        def _run(cmd, **kw):  # noqa: ANN001, ANN003
+            state["cmds"].append(cmd)
+            if cmd[0] == "curl":
+                return SimpleNamespace(returncode=curl_rc, stdout=curl_stdout)
+            if sudo_raises:
+                raise subprocess.CalledProcessError(1, cmd)
+            if cmd[:2] == ["sudo", "mv"]:
+                state["installed"] = True
+            return SimpleNamespace(returncode=0, stdout=b"")
+
+        monkeypatch.setattr(install.subprocess, "run", _run)
+        return state
+
+    def test_raw_binary_success_uses_f_flag(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        state = self._wire(monkeypatch)
+        assert install.install_ci_binary("tool", "http://x") == "/usr/local/bin/tool"
+        # curl -f: fail on HTTP error instead of saving a 404 page as the binary.
+        assert any(c[0] == "curl" and "-fsSL" in c for c in state["cmds"])
+
+    def test_tar_member_extracted(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._wire(monkeypatch, curl_stdout=_make_targz("tool"))
+        assert (
+            install.install_ci_binary("tool", "http://x", tar_member="tool")
+            == "/usr/local/bin/tool"
+        )
+
+    def test_tar_member_missing_returns_none(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._wire(monkeypatch, curl_stdout=_make_targz("other"))
+        assert install.install_ci_binary("tool", "http://x", tar_member="tool") is None
+
+    def test_curl_failure_returns_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._wire(monkeypatch, curl_rc=1)
+        assert install.install_ci_binary("tool", "http://x") is None
+
+    def test_sudo_failure_returns_none_not_crash(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A hardened runner without passwordless sudo must yield None, not a
+        # CalledProcessError crashing the whole quality stage.
+        self._wire(monkeypatch, sudo_raises=True)
+        assert install.install_ci_binary("tool", "http://x") is None

--- a/tests/unit/test_kube_linter.py
+++ b/tests/unit/test_kube_linter.py
@@ -1,0 +1,90 @@
+# Project:   HyperI CI
+# File:      tests/unit/test_kube_linter.py
+# Purpose:   Tests for the kube-linter k8s best-practice advisory
+#
+# License:   BUSL-1.1 - HYPERI PTY LIMITED
+# Copyright: (c) 2026 HYPERI PTY LIMITED
+"""Tests for hyperi_ci.quality.kube_linter - advisory only, never gates."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from hyperi_ci.config import CIConfig
+from hyperi_ci.quality import kube_linter
+
+_SARIF = json.dumps(
+    {
+        "runs": [
+            {
+                "tool": {"driver": {"name": "kube-linter", "rules": []}},
+                "results": [
+                    {
+                        "ruleId": "no-read-only-root-fs",
+                        "level": "warning",
+                        "message": {"text": "container should run read-only"},
+                        "locations": [
+                            {"physicalLocation": {"artifactLocation": {"uri": "chart"}}}
+                        ],
+                    }
+                ],
+            }
+        ]
+    }
+)
+
+
+def _cfg(raw: dict | None = None) -> CIConfig:
+    return CIConfig(_raw=raw or {})
+
+
+def _stub(
+    monkeypatch: pytest.MonkeyPatch,
+    stdout: str,
+    *,
+    exe: str | None = "/usr/bin/kube-linter",
+) -> None:
+    monkeypatch.setattr(kube_linter, "_install_kube_linter", lambda: exe)
+    monkeypatch.setattr(kube_linter, "find_tool", lambda *a, **k: exe)
+    monkeypatch.setattr(
+        kube_linter,
+        "run_cmd",
+        lambda *a, **k: SimpleNamespace(stdout=stdout, returncode=1),
+    )
+
+
+class TestRun:
+    def test_disabled(self) -> None:
+        assert (
+            kube_linter.run(
+                [Path("chart")], _cfg({"quality": {"kube_linter": "disabled"}})
+            )
+            == 0
+        )
+
+    def test_no_targets_skips(self) -> None:
+        assert kube_linter.run([], _cfg()) == 0
+
+    def test_findings_never_fail(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _stub(monkeypatch, _SARIF)
+        # returncode 1 from kube-linter (it found violations) must NOT propagate.
+        assert kube_linter.run([Path("chart")], _cfg()) == 0
+
+    def test_missing_tool_info_skips(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _stub(monkeypatch, "", exe=None)
+        assert kube_linter.run([Path("chart")], _cfg()) == 0
+
+    def test_oserror_swallowed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            kube_linter, "_install_kube_linter", lambda: "/usr/bin/kube-linter"
+        )
+
+        def _boom(*a, **k):  # noqa: ANN002, ANN003
+            raise OSError("exec failed")
+
+        monkeypatch.setattr(kube_linter, "run_cmd", _boom)
+        assert kube_linter.run([Path("chart")], _cfg()) == 0

--- a/tests/unit/test_kubeconform.py
+++ b/tests/unit/test_kubeconform.py
@@ -1,0 +1,206 @@
+# Project:   HyperI CI
+# File:      tests/unit/test_kubeconform.py
+# Purpose:   Tests for the kubeconform k8s schema-validation gate
+#
+# License:   BUSL-1.1 - HYPERI PTY LIMITED
+# Copyright: (c) 2026 HYPERI PTY LIMITED
+"""Tests for hyperi_ci.quality.kubeconform."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from hyperi_ci.config import CIConfig
+from hyperi_ci.quality import kubeconform
+
+_SKIP = "HYPERCI_QUALITY_SKIP"
+
+
+def _cfg(raw: dict | None = None) -> CIConfig:
+    return CIConfig(_raw=raw or {})
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(_SKIP, raising=False)
+    monkeypatch.delenv("HYPERCI_QUALITY_STRICT", raising=False)
+
+
+def _stub(
+    monkeypatch: pytest.MonkeyPatch,
+    stdout: str,
+    *,
+    exe: str | None = "/usr/bin/kubeconform",
+) -> None:
+    monkeypatch.setattr(kubeconform, "_install_kubeconform", lambda: exe)
+    monkeypatch.setattr(
+        kubeconform,
+        "run_cmd",
+        lambda *a, **k: SimpleNamespace(stdout=stdout, returncode=0),
+    )
+
+
+class TestParse:
+    def test_invalid_and_error_are_findings(self) -> None:
+        payload = json.dumps(
+            {
+                "resources": [
+                    {
+                        "filename": "a.yaml",
+                        "kind": "Deployment",
+                        "name": "x",
+                        "status": "statusInvalid",
+                        "msg": "bad",
+                    },
+                    {
+                        "filename": "b.yaml",
+                        "kind": "Service",
+                        "name": "y",
+                        "status": "statusValid",
+                        "msg": "",
+                    },
+                    {
+                        "filename": "c.yaml",
+                        "kind": "Foo",
+                        "name": "z",
+                        "status": "statusSkipped",
+                        "msg": "",
+                    },
+                ]
+            }
+        )
+        found = kubeconform._parse(payload)
+        assert len(found) == 1
+        assert found[0].level == "error"
+        assert found[0].path == "a.yaml"
+        assert "Deployment" in found[0].rule
+
+    def test_uppercase_status(self) -> None:
+        payload = json.dumps(
+            {
+                "resources": [
+                    {"filename": "a", "kind": "X", "status": "INVALID", "msg": "m"}
+                ]
+            }
+        )
+        assert len(kubeconform._parse(payload)) == 1
+
+    def test_blank(self) -> None:
+        assert kubeconform._parse("") == []
+        assert kubeconform._parse("not json") == []
+
+
+class TestSchemaLocations:
+    def test_default_includes_catalog(self) -> None:
+        locs = kubeconform._schema_locations(_cfg())
+        assert locs[0] == "default"
+        assert any("datreeio" in loc for loc in locs)
+
+    def test_extra_appended(self) -> None:
+        cfg = _cfg({"quality": {"kubeconform": {"schema_locations": ["/my/crds"]}}})
+        assert "/my/crds" in kubeconform._schema_locations(cfg)
+
+
+class TestRun:
+    def test_no_manifests_skips(self) -> None:
+        assert kubeconform.run([], _cfg()) == 0
+
+    def test_disabled(self) -> None:
+        assert (
+            kubeconform.run(
+                [Path("a.yaml")], _cfg({"quality": {"kubeconform": "disabled"}})
+            )
+            == 0
+        )
+
+    def test_blocking_fails_on_invalid(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _stub(
+            monkeypatch,
+            json.dumps(
+                {
+                    "resources": [
+                        {
+                            "filename": "a",
+                            "kind": "X",
+                            "status": "statusInvalid",
+                            "msg": "m",
+                        }
+                    ]
+                }
+            ),
+        )
+        assert kubeconform.run([Path("a.yaml")], _cfg()) == 1
+
+    def test_valid_passes(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _stub(
+            monkeypatch,
+            json.dumps(
+                {"resources": [{"filename": "a", "kind": "X", "status": "statusValid"}]}
+            ),
+        )
+        assert kubeconform.run([Path("a.yaml")], _cfg()) == 0
+
+    def test_warn_never_fails(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _stub(
+            monkeypatch,
+            json.dumps(
+                {
+                    "resources": [
+                        {
+                            "filename": "a",
+                            "kind": "X",
+                            "status": "statusInvalid",
+                            "msg": "m",
+                        }
+                    ]
+                }
+            ),
+        )
+        assert (
+            kubeconform.run(
+                [Path("a.yaml")], _cfg({"quality": {"kubeconform": "warn"}})
+            )
+            == 0
+        )
+
+    def test_missing_tool_blocks_in_ci(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(kubeconform, "_install_kubeconform", lambda: None)
+        monkeypatch.setattr(kubeconform, "is_ci", lambda: True)
+        assert kubeconform.run([Path("a.yaml")], _cfg()) == 1
+
+    def test_missing_tool_warn_skips_locally(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(kubeconform, "_install_kubeconform", lambda: None)
+        monkeypatch.setattr(kubeconform, "is_ci", lambda: False)
+        assert kubeconform.run([Path("a.yaml")], _cfg()) == 0
+
+    def test_tool_error_blocks_in_ci(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Non-zero exit with no parseable resources = a tool error (bad schema
+        # location, unreadable input), not "all valid" - blocking gate fails.
+        monkeypatch.setattr(
+            kubeconform, "_install_kubeconform", lambda: "/usr/bin/kubeconform"
+        )
+        monkeypatch.setattr(
+            kubeconform,
+            "run_cmd",
+            lambda *a, **k: SimpleNamespace(stdout="", returncode=2),
+        )
+        monkeypatch.setattr(kubeconform, "is_ci", lambda: True)
+        assert kubeconform.run([Path("a.yaml")], _cfg()) == 1
+
+    def test_exec_oserror_does_not_crash(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            kubeconform, "_install_kubeconform", lambda: "/usr/bin/kubeconform"
+        )
+
+        def _boom(*a, **k):  # noqa: ANN002, ANN003
+            raise OSError("exec failed")
+
+        monkeypatch.setattr(kubeconform, "run_cmd", _boom)
+        monkeypatch.setattr(kubeconform, "is_ci", lambda: False)
+        assert kubeconform.run([Path("a.yaml")], _cfg()) == 0

--- a/tests/unit/test_lint_manifests.py
+++ b/tests/unit/test_lint_manifests.py
@@ -1,0 +1,169 @@
+# Project:   HyperI CI
+# File:      tests/unit/test_lint_manifests.py
+# Purpose:   Tests for the lint-manifests orchestrator (Path B)
+#
+# License:   BUSL-1.1 - HYPERI PTY LIMITED
+# Copyright: (c) 2026 HYPERI PTY LIMITED
+"""Tests for hyperi_ci.quality.lint_manifests - the k8s/IaC orchestrator.
+
+kubeconform gates always; Checkov gates only when escalated to blocking;
+kube-linter is always advisory. All tools run even after a gate fails. Sub-tools
+are mocked here - this pins the orchestration, not the tools.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hyperi_ci.config import CIConfig
+from hyperi_ci.quality import lint_manifests
+
+
+def _cfg() -> CIConfig:
+    return CIConfig(_raw={})
+
+
+@pytest.fixture
+def _wire(monkeypatch: pytest.MonkeyPatch) -> dict:
+    """Mock discovery + the three tools; record which ran."""
+    calls: dict = {"kubeconform": 0, "kube_linter": 0, "checkov": 0, "rendered": None}
+
+    monkeypatch.setattr(
+        lint_manifests, "discover_helm_charts", lambda *a, **k: [Path("charts/svc")]
+    )
+    monkeypatch.setattr(
+        lint_manifests, "discover_manifests", lambda *a, **k: [Path("argocd/app.yaml")]
+    )
+    monkeypatch.setattr(lint_manifests.render, "helm_available", lambda: True)
+    monkeypatch.setattr(
+        lint_manifests.render, "render_charts", lambda charts, out: [Path("r.yaml")]
+    )
+
+    def _kc(targets, config, **k):  # noqa: ANN001, ANN003
+        calls["kubeconform"] += 1
+        calls["kc_targets"] = targets
+        return calls.get("kc_rc", 0)
+
+    def _kl(targets, config, **k):  # noqa: ANN001, ANN003
+        calls["kube_linter"] += 1
+        return 0
+
+    def _cv(root, config, **k):  # noqa: ANN001, ANN003
+        calls["checkov"] += 1
+        return calls.get("cv_rc", 0)
+
+    monkeypatch.setattr(lint_manifests.kubeconform, "run", _kc)
+    monkeypatch.setattr(lint_manifests.kube_linter, "run", _kl)
+    monkeypatch.setattr(lint_manifests.checkov, "run", _cv)
+    return calls
+
+
+class TestRun:
+    def test_gate_pass_returns_zero(self, _wire: dict, tmp_path: Path) -> None:
+        assert lint_manifests.run(tmp_path, _cfg()) == 0
+
+    def test_gate_failure_propagates(self, _wire: dict, tmp_path: Path) -> None:
+        _wire["kc_rc"] = 1
+        assert lint_manifests.run(tmp_path, _cfg()) == 1
+
+    def test_all_tools_run(self, _wire: dict, tmp_path: Path) -> None:
+        lint_manifests.run(tmp_path, _cfg())
+        assert _wire["kubeconform"] == 1
+        assert _wire["kube_linter"] == 1
+        assert _wire["checkov"] == 1
+
+    def test_advisories_run_even_when_gate_fails(
+        self, _wire: dict, tmp_path: Path
+    ) -> None:
+        _wire["kc_rc"] = 1
+        lint_manifests.run(tmp_path, _cfg())
+        assert _wire["kube_linter"] == 1 and _wire["checkov"] == 1
+
+    def test_blocking_checkov_fails_verb_even_when_gate_passes(
+        self, _wire: dict, tmp_path: Path
+    ) -> None:
+        # kubeconform passes (0) but a blocking Checkov returns 1 -> verb fails.
+        _wire["kc_rc"] = 0
+        _wire["cv_rc"] = 1
+        assert lint_manifests.run(tmp_path, _cfg()) == 1
+
+    def test_kubeconform_gets_rendered_plus_plain(
+        self, _wire: dict, tmp_path: Path
+    ) -> None:
+        lint_manifests.run(tmp_path, _cfg())
+        # rendered chart (r.yaml) + plain manifest (argocd/app.yaml)
+        assert Path("r.yaml") in _wire["kc_targets"]
+        assert Path("argocd/app.yaml") in _wire["kc_targets"]
+
+    def test_helm_unavailable_still_runs_advisories(
+        self, _wire: dict, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(lint_manifests.render, "helm_available", lambda: False)
+        monkeypatch.setattr(lint_manifests, "is_ci", lambda: False)
+        lint_manifests.run(tmp_path, _cfg())
+        # No rendered charts, but the plain manifest is still validated.
+        assert _wire["kc_targets"] == [Path("argocd/app.yaml")]
+        assert _wire["kube_linter"] == 1
+
+    def test_helm_absent_blocking_gate_fails_in_ci(
+        self, _wire: dict, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A chart exists, helm is absent, kubeconform is blocking (default) and
+        # we are in CI -> the gate must NOT pass green having skipped the chart.
+        monkeypatch.setattr(lint_manifests.render, "helm_available", lambda: False)
+        monkeypatch.setattr(lint_manifests, "is_ci", lambda: True)
+        _wire["kc_rc"] = 0
+        assert lint_manifests.run(tmp_path, _cfg()) == 1
+
+    def test_helm_absent_locally_does_not_force_fail(
+        self, _wire: dict, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(lint_manifests.render, "helm_available", lambda: False)
+        monkeypatch.setattr(lint_manifests, "is_ci", lambda: False)
+        _wire["kc_rc"] = 0
+        assert lint_manifests.run(tmp_path, _cfg()) == 0
+
+    def test_render_failure_fails_blocking_gate_in_ci(
+        self, _wire: dict, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # helm IS available but the chart fails to render (render_charts returns
+        # fewer than discovered) -> the chart was not schema-validated, so a
+        # blocking gate must fail rather than pass green (No silent skips).
+        monkeypatch.setattr(
+            lint_manifests.render, "render_charts", lambda charts, out: []
+        )
+        monkeypatch.setattr(lint_manifests, "is_ci", lambda: True)
+        _wire["kc_rc"] = 0
+        assert lint_manifests.run(tmp_path, _cfg()) == 1
+
+    def test_no_targets_blocking_checkov_gates(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Pure-IaC repo, no charts/manifests, blocking Checkov finds something
+        # -> the verb fails (consistent with the has-manifests path).
+        monkeypatch.setattr(lint_manifests, "discover_helm_charts", lambda *a, **k: [])
+        monkeypatch.setattr(lint_manifests, "discover_manifests", lambda *a, **k: [])
+        monkeypatch.setattr(lint_manifests.checkov, "run", lambda *a, **k: 1)
+        assert lint_manifests.run(tmp_path, _cfg()) == 1
+
+    def test_no_targets_runs_checkov_only(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(lint_manifests, "discover_helm_charts", lambda *a, **k: [])
+        monkeypatch.setattr(lint_manifests, "discover_manifests", lambda *a, **k: [])
+        ran = {"checkov": 0, "kubeconform": 0}
+        monkeypatch.setattr(
+            lint_manifests.checkov,
+            "run",
+            lambda *a, **k: ran.__setitem__("checkov", 1) or 0,
+        )
+        monkeypatch.setattr(
+            lint_manifests.kubeconform,
+            "run",
+            lambda *a, **k: ran.__setitem__("kubeconform", 1) or 0,
+        )
+        assert lint_manifests.run(tmp_path, _cfg()) == 0
+        assert ran["checkov"] == 1
+        assert ran["kubeconform"] == 0  # nothing to schema-validate

--- a/tests/unit/test_render.py
+++ b/tests/unit/test_render.py
@@ -1,0 +1,85 @@
+# Project:   HyperI CI
+# File:      tests/unit/test_render.py
+# Purpose:   Tests for Helm chart rendering (kubeconform input prep)
+#
+# License:   BUSL-1.1 - HYPERI PTY LIMITED
+# Copyright: (c) 2026 HYPERI PTY LIMITED
+"""Tests for hyperi_ci.quality.render.render_charts (helm mocked)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from hyperi_ci.quality import render
+
+
+def _mock_helm(monkeypatch: pytest.MonkeyPatch, *, template_ok: bool = True) -> None:
+    def _run(cmd, **kw):  # noqa: ANN001, ANN003
+        if "template" in cmd:
+            return SimpleNamespace(
+                returncode=0 if template_ok else 1,
+                stdout="apiVersion: apps/v1\nkind: Deployment\n" if template_ok else "",
+            )
+        return SimpleNamespace(returncode=0, stdout="")  # dependency build
+
+    monkeypatch.setattr(render, "run_cmd", _run)
+
+
+class TestRenderCharts:
+    def test_renders_each_chart(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _mock_helm(monkeypatch)
+        chart = tmp_path / "svc"
+        chart.mkdir()
+        out = tmp_path / "out"
+        rendered = render.render_charts([chart], out)
+        assert len(rendered) == 1
+        assert rendered[0].name == "svc.rendered.yaml"
+        assert "kind: Deployment" in rendered[0].read_text(encoding="utf-8")
+
+    def test_skips_unrenderable(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _mock_helm(monkeypatch, template_ok=False)
+        chart = tmp_path / "svc"
+        chart.mkdir()
+        rendered = render.render_charts([chart], tmp_path / "out")
+        assert rendered == []
+
+
+class TestReleaseName:
+    @pytest.mark.parametrize(
+        ("dirname", "expected"),
+        [
+            ("web", "web"),
+            ("Chart", "chart"),  # capital dir would break `helm template`
+            ("my_chart", "my-chart"),  # underscore is invalid in a release name
+            ("UPPER_Case", "upper-case"),
+            ("--x--", "x"),
+            ("___", "chart"),  # empty after sanitising -> fallback
+        ],
+    )
+    def test_sanitises(self, tmp_path: Path, dirname: str, expected: str) -> None:
+        assert render._release_name(tmp_path / dirname) == expected
+
+    def test_render_uses_sanitised_release_name(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        captured: dict = {}
+
+        def _run(cmd, **kw):  # noqa: ANN001, ANN003
+            if "template" in cmd:
+                captured["cmd"] = cmd
+                return SimpleNamespace(returncode=0, stdout="kind: X\n")
+            return SimpleNamespace(returncode=0, stdout="")
+
+        monkeypatch.setattr(render, "run_cmd", _run)
+        chart = tmp_path / "Chart"  # capital - would fail helm without sanitising
+        chart.mkdir()
+        render.render_charts([chart], tmp_path / "out")
+        # `helm template <release> <chart>` - release name must be lowercase.
+        assert captured["cmd"][2] == "chart"

--- a/tests/unit/test_targets.py
+++ b/tests/unit/test_targets.py
@@ -1,0 +1,155 @@
+# Project:   HyperI CI
+# File:      tests/unit/test_targets.py
+# Purpose:   Tests for lint-target discovery (Dockerfiles)
+#
+# License:   BUSL-1.1 - HYPERI PTY LIMITED
+# Copyright: (c) 2026 HYPERI PTY LIMITED
+"""Tests for hyperi_ci.quality.targets.discover_dockerfiles."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from hyperi_ci.quality.targets import (
+    discover_dockerfiles,
+    discover_helm_charts,
+    discover_manifests,
+)
+
+
+def _touch(p: Path) -> None:
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text("FROM scratch\n", encoding="utf-8")
+
+
+class TestDiscoverDockerfiles:
+    def test_matches_all_forms(self, tmp_path: Path) -> None:
+        _touch(tmp_path / "Dockerfile")
+        _touch(tmp_path / "Dockerfile.dev")
+        _touch(tmp_path / "app.Dockerfile")
+        _touch(tmp_path / "Containerfile")
+        _touch(tmp_path / "svc" / "Dockerfile")
+        found = {p.name for p in discover_dockerfiles(tmp_path)}
+        assert found == {
+            "Dockerfile",
+            "Dockerfile.dev",
+            "app.Dockerfile",
+            "Containerfile",
+        }
+
+    def test_ignores_dockerignore(self, tmp_path: Path) -> None:
+        _touch(tmp_path / "Dockerfile")
+        (tmp_path / ".dockerignore").write_text("node_modules\n", encoding="utf-8")
+        found = [p.name for p in discover_dockerfiles(tmp_path)]
+        assert ".dockerignore" not in found
+        assert "Dockerfile" in found
+
+    def test_prunes_default_dirs(self, tmp_path: Path) -> None:
+        # A Dockerfile inside an always-pruned dir must not be discovered - this
+        # is the .worktrees duplicate-tree double-count guard.
+        _touch(tmp_path / "Dockerfile")
+        _touch(tmp_path / ".worktrees" / "branch" / "Dockerfile")
+        _touch(tmp_path / "node_modules" / "pkg" / "Dockerfile")
+        found = [p for p in discover_dockerfiles(tmp_path)]
+        assert len(found) == 1
+        assert found[0] == tmp_path / "Dockerfile"
+
+    def test_respects_extra_excludes(self, tmp_path: Path) -> None:
+        _touch(tmp_path / "Dockerfile")
+        _touch(tmp_path / "third_party" / "Dockerfile")
+        found = discover_dockerfiles(tmp_path, exclude_dirs=["third_party"])
+        assert [p.parent.name for p in found] == [tmp_path.name]
+
+    def test_empty_when_none(self, tmp_path: Path) -> None:
+        (tmp_path / "README.md").write_text("hi\n", encoding="utf-8")
+        assert discover_dockerfiles(tmp_path) == []
+
+    def test_sorted_output(self, tmp_path: Path) -> None:
+        _touch(tmp_path / "b.Dockerfile")
+        _touch(tmp_path / "a.Dockerfile")
+        found = discover_dockerfiles(tmp_path)
+        assert found == sorted(found)
+
+
+def _chart(dir_: Path, *, library: bool = False) -> None:
+    dir_.mkdir(parents=True, exist_ok=True)
+    body = "apiVersion: v2\nname: c\nversion: 0.1.0\n"
+    if library:
+        body += "type: library\n"
+    (dir_ / "Chart.yaml").write_text(body, encoding="utf-8")
+
+
+class TestDiscoverHelmCharts:
+    def test_finds_top_level_skips_library_and_subcharts(self, tmp_path: Path) -> None:
+        _chart(tmp_path / "charts" / "svc")
+        _chart(tmp_path / "charts" / "svc" / "charts" / "sub")  # subchart
+        _chart(tmp_path / "library" / "common", library=True)  # library type
+        found = discover_helm_charts(tmp_path)
+        assert found == [tmp_path / "charts" / "svc"]
+
+    def test_prunes_worktrees(self, tmp_path: Path) -> None:
+        _chart(tmp_path / "charts" / "svc")
+        _chart(tmp_path / ".worktrees" / "branch" / "charts" / "svc")
+        found = discover_helm_charts(tmp_path)
+        assert found == [tmp_path / "charts" / "svc"]
+
+
+class TestDiscoverManifests:
+    def test_only_apiversion_kind_docs(self, tmp_path: Path) -> None:
+        # deploy.yaml has apiVersion+kind; values.yaml does not -> only deploy.
+        (tmp_path / "deploy.yaml").write_text(
+            "apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: x\n",
+            encoding="utf-8",
+        )
+        (tmp_path / "values.yaml").write_text(
+            "replicas: 3\nimage: x\n", encoding="utf-8"
+        )
+        found = [p.name for p in discover_manifests(tmp_path)]
+        assert found == ["deploy.yaml"]
+
+    def test_skips_chart_content(self, tmp_path: Path) -> None:
+        # A chart's templates/ + values.yaml must NOT be picked up as plain
+        # manifests - they are rendered separately. Even a template that happens
+        # to parse as YAML is excluded because it lives inside a chart.
+        chart = tmp_path / "charts" / "svc"
+        (chart / "templates").mkdir(parents=True)
+        (chart / "Chart.yaml").write_text(
+            "apiVersion: v2\nname: svc\n", encoding="utf-8"
+        )
+        (chart / "values.yaml").write_text("replicas: 1\n", encoding="utf-8")
+        (chart / "templates" / "dep.yaml").write_text(
+            "apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: x\n",
+            encoding="utf-8",
+        )
+        assert discover_manifests(tmp_path) == []
+
+    def test_finds_manifest_outside_chart(self, tmp_path: Path) -> None:
+        # A plain manifest not inside a chart IS discovered.
+        (tmp_path / "argocd").mkdir()
+        (tmp_path / "argocd" / "app.yaml").write_text(
+            "apiVersion: argoproj.io/v1alpha1\nkind: Application\nmetadata:\n  name: a\n",
+            encoding="utf-8",
+        )
+        assert [p.name for p in discover_manifests(tmp_path)] == ["app.yaml"]
+
+    def test_multi_doc_file_counts(self, tmp_path: Path) -> None:
+        (tmp_path / "multi.yaml").write_text(
+            "replicas: 1\n---\napiVersion: v1\nkind: Service\nmetadata:\n  name: s\n",
+            encoding="utf-8",
+        )
+        assert [p.name for p in discover_manifests(tmp_path)] == ["multi.yaml"]
+
+    def test_repo_is_chart_at_root_skips_everything(self, tmp_path: Path) -> None:
+        # When the discovery root IS a chart, every file is chart content ->
+        # discover_manifests returns nothing (it is all rendered separately).
+        (tmp_path / "Chart.yaml").write_text(
+            "apiVersion: v2\nname: c\n", encoding="utf-8"
+        )
+        (tmp_path / "manifest.yaml").write_text(
+            "apiVersion: v1\nkind: Service\nmetadata:\n  name: s\n", encoding="utf-8"
+        )
+        assert discover_manifests(tmp_path) == []
+
+    def test_chart_at_root_is_discovered_as_chart(self, tmp_path: Path) -> None:
+        _chart(tmp_path)
+        assert discover_helm_charts(tmp_path) == [tmp_path]


### PR DESCRIPTION
hadolint (gate) + droast (advisory) for Dockerfiles in the quality stage (Path A); kubeconform (gate) + kube-linter + checkov via a new `hyperi-ci lint-manifests` verb for gitops/infra repos (Path B). Shared finding surface (capped annotations + job summary + opt-in SARIF). gitops scaffold migrated Terraform->OpenTofu.

Verified with real binaries (hadolint, kubeconform+helm, checkov via uvx); 1400+ unit tests; two adversarial reviews remedied; docs auditor ship-ready. Fixture ci-test-manifests found + fixed a real silent-skip render bug (chart-dir-name used as helm release name).

Rollout issues: hyperi-io/dfe-docker#30, hyperi-io/dfe-infra#16, hyperi-io/dfe-engine#107, hyperi-io/dfe-ui#113. Closes #69.