### PR TITLE
fix(cli): add install-all for runner image bake

### DIFF
--- a/.github/actions/setup-go-tools/action.yml
+++ b/.github/actions/setup-go-tools/action.yml
@@ -44,7 +44,7 @@ inputs:
     description: gosec release tag to pin (must include the leading `v`)
     required: false
     # hyperi-ci:pin tools.gosec
-    default: v2.27.1
+    default: v2.28.0
   govulncheck-version:
     description: govulncheck module version to pin (no prebuilt binaries upstream)
     required: false

--- a/.github/actions/setup-runtime/action.yml
+++ b/.github/actions/setup-runtime/action.yml
@@ -40,7 +40,7 @@ runs:
   steps:
     - name: Install uv
       if: ${{ !contains(runner.name, 'arc-runner') }}
-      uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+      uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
       with:
         enable-cache: ${{ inputs.enable-uv-cache }}
 

--- a/.github/actions/setup-runtime/action.yml
+++ b/.github/actions/setup-runtime/action.yml
@@ -40,7 +40,7 @@ runs:
   steps:
     - name: Install uv
       if: ${{ !contains(runner.name, 'arc-runner') }}
-      uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+      uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
       with:
         enable-cache: ${{ inputs.enable-uv-cache }}
 

--- a/.github/actions/setup-semantic-release/action.yml
+++ b/.github/actions/setup-semantic-release/action.yml
@@ -38,7 +38,7 @@ runs:
   using: composite
   steps:
     - name: Set up Node.js
-      uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       with:
         node-version: ${{ inputs.node-version }}
 

--- a/.github/actions/setup-semantic-release/action.yml
+++ b/.github/actions/setup-semantic-release/action.yml
@@ -38,7 +38,7 @@ runs:
   using: composite
   steps:
     - name: Set up Node.js
-      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
       with:
         node-version: ${{ inputs.node-version }}
 

--- a/.github/workflows/_ghcr-prune.yml
+++ b/.github/workflows/_ghcr-prune.yml
@@ -64,7 +64,7 @@ jobs:
       packages: write
     steps:
       - name: Prune branch-mode dev tags
-        uses: dataaxiom/ghcr-cleanup-action@cd0cdb900b5dbf3a6f2cc869f0dbb0b8211f50c4 # v1.0.16
+        uses: dataaxiom/ghcr-cleanup-action@d52806a0dc70b430571a37da1fde39733ffd640f # v1.2.2
         with:
           package: ${{ inputs.package || github.event.repository.name }}
           delete-tags: "branch-*,dev-sha-*"

--- a/.github/workflows/_release-tail.yml
+++ b/.github/workflows/_release-tail.yml
@@ -118,7 +118,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.tag || github.ref }}
 
@@ -131,7 +131,7 @@ jobs:
       - name: Install uv
         # Needed to run the resolve step below. Cheap, no Docker Hub —
         # so a library never pays the Buildx/Docker-Hub cost (issue #33).
-        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           enable-cache: false
 
@@ -223,7 +223,7 @@ jobs:
       pull-requests: write
       packages: write
     steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # On push OR a from-head dispatch (issue #35), check out main HEAD
           # so the tag is created there. On a tag dispatch (retroactive
@@ -318,7 +318,7 @@ jobs:
           toolchain: ${{ inputs.rust-toolchain }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           enable-cache: false
 

--- a/.github/workflows/_release-tail.yml
+++ b/.github/workflows/_release-tail.yml
@@ -118,7 +118,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           ref: ${{ inputs.tag || github.ref }}
 
@@ -131,7 +131,7 @@ jobs:
       - name: Install uv
         # Needed to run the resolve step below. Cheap, no Docker Hub —
         # so a library never pays the Buildx/Docker-Hub cost (issue #33).
-        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           enable-cache: false
 
@@ -223,7 +223,7 @@ jobs:
       pull-requests: write
       packages: write
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           # On push OR a from-head dispatch (issue #35), check out main HEAD
           # so the tag is created there. On a tag dispatch (retroactive
@@ -313,12 +313,12 @@ jobs:
 
       - name: Install Rust toolchain
         if: inputs.language == 'rust'
-        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
         with:
           toolchain: ${{ inputs.rust-toolchain }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           enable-cache: false
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
       will-publish: ${{ steps.predict.outputs.will-publish }}
       next-version: ${{ steps.predict.outputs.version }}
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           ref: ${{ inputs.tag || github.ref }}
           fetch-depth: 0  # full history - semantic-release dry-run reads it
@@ -96,11 +96,11 @@ jobs:
       github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           fetch-depth: 0
       - name: Install uv
-        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           enable-cache: true
       - name: Set up Python
@@ -114,7 +114,7 @@ jobs:
     name: Quality
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           ref: ${{ inputs.tag || github.ref }}
           # Full history + tags: the interface gate diffs against the last
@@ -122,7 +122,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           enable-cache: true
 
@@ -162,12 +162,12 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           ref: ${{ inputs.tag || github.ref }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           enable-cache: true
 
@@ -186,7 +186,7 @@ jobs:
     if: needs.plan.outputs.run-build == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           ref: ${{ inputs.tag || github.ref }}
 
@@ -214,7 +214,7 @@ jobs:
           fi
 
       - name: Install uv
-        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           enable-cache: true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
       will-publish: ${{ steps.predict.outputs.will-publish }}
       next-version: ${{ steps.predict.outputs.version }}
     steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.tag || github.ref }}
           fetch-depth: 0  # full history - semantic-release dry-run reads it
@@ -96,11 +96,11 @@ jobs:
       github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
       - name: Install uv
-        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           enable-cache: true
       - name: Set up Python
@@ -114,7 +114,7 @@ jobs:
     name: Quality
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.tag || github.ref }}
           # Full history + tags: the interface gate diffs against the last
@@ -122,7 +122,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           enable-cache: true
 
@@ -162,12 +162,12 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
     steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.tag || github.ref }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           enable-cache: true
 
@@ -186,7 +186,7 @@ jobs:
     if: needs.plan.outputs.run-build == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.tag || github.ref }}
 
@@ -214,7 +214,7 @@ jobs:
           fi
 
       - name: Install uv
-        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           enable-cache: true
 

--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -150,7 +150,7 @@ jobs:
       - name: Beta notice
         run: echo "::warning title=Go CI is beta::The Go reusable workflow is less battle-tested than Rust/Python/TS — verify results carefully."
 
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.tag || github.ref }}
           fetch-depth: 0
@@ -196,11 +196,11 @@ jobs:
       github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
       - name: Install uv
-        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           enable-cache: false
       - name: Validate commit messages
@@ -219,13 +219,13 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.tag || github.ref }}
 
       - name: Set up Go
         if: ${{ !contains(runner.name, 'arc-runner') }}
-        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: ${{ inputs.go-version-file }}
 
@@ -234,7 +234,7 @@ jobs:
 
       - name: Install uv
         if: ${{ !contains(runner.name, 'arc-runner') }}
-        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           enable-cache: false
 
@@ -275,19 +275,19 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.tag || github.ref }}
 
       - name: Set up Go
         if: ${{ !contains(runner.name, 'arc-runner') }}
-        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: ${{ inputs.go-version-file }}
 
       - name: Install uv
         if: ${{ !contains(runner.name, 'arc-runner') }}
-        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           enable-cache: false
 
@@ -325,7 +325,7 @@ jobs:
     strategy:
       matrix: ${{ fromJson(needs.plan.outputs.build-matrix) }}
     steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.tag || github.ref }}
 
@@ -351,13 +351,13 @@ jobs:
 
       - name: Set up Go
         if: ${{ !contains(runner.name, 'arc-runner') }}
-        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: ${{ inputs.go-version-file }}
 
       - name: Install uv
         if: ${{ !contains(runner.name, 'arc-runner') }}
-        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           enable-cache: false
 

--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -150,7 +150,7 @@ jobs:
       - name: Beta notice
         run: echo "::warning title=Go CI is beta::The Go reusable workflow is less battle-tested than Rust/Python/TS — verify results carefully."
 
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           ref: ${{ inputs.tag || github.ref }}
           fetch-depth: 0
@@ -196,11 +196,11 @@ jobs:
       github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           fetch-depth: 0
       - name: Install uv
-        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           enable-cache: false
       - name: Validate commit messages
@@ -219,7 +219,7 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           ref: ${{ inputs.tag || github.ref }}
 
@@ -234,7 +234,7 @@ jobs:
 
       - name: Install uv
         if: ${{ !contains(runner.name, 'arc-runner') }}
-        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           enable-cache: false
 
@@ -275,7 +275,7 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           ref: ${{ inputs.tag || github.ref }}
 
@@ -287,7 +287,7 @@ jobs:
 
       - name: Install uv
         if: ${{ !contains(runner.name, 'arc-runner') }}
-        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           enable-cache: false
 
@@ -325,7 +325,7 @@ jobs:
     strategy:
       matrix: ${{ fromJson(needs.plan.outputs.build-matrix) }}
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           ref: ${{ inputs.tag || github.ref }}
 
@@ -357,7 +357,7 @@ jobs:
 
       - name: Install uv
         if: ${{ !contains(runner.name, 'arc-runner') }}
-        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           enable-cache: false
 

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -151,7 +151,7 @@ jobs:
       will-publish: ${{ steps.predict.outputs.will-publish }}
       next-version: ${{ steps.predict.outputs.version }}
     steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.tag || github.ref }}
           fetch-depth: 0  # full history — semantic-release dry-run reads it
@@ -179,11 +179,11 @@ jobs:
       github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
       - name: Install uv
-        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           enable-cache: false
       - name: Validate commit messages
@@ -202,13 +202,13 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.tag || github.ref }}
 
       - name: Install uv
         if: ${{ !contains(runner.name, 'arc-runner') }}
-        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           enable-cache: true
 
@@ -257,13 +257,13 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.tag || github.ref }}
 
       - name: Install uv
         if: ${{ !contains(runner.name, 'arc-runner') }}
-        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           enable-cache: true
 
@@ -302,7 +302,7 @@ jobs:
     if: needs.plan.outputs.run-build == 'true'
     runs-on: ${{ startsWith(github.head_ref || github.ref_name, 'renovate/') && (vars.GH_RUNNER_RENOVATE || 'ubuntu-latest') || (inputs.runner-mode || vars.GH_RUNNER_MODE) == 'free' && 'ubuntu-latest' || inputs.runner-build || vars.GH_RUNNER_PYTHON || vars.GH_RUNNER_DEFAULT || 'ubuntu-latest' }}
     steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.tag || github.ref }}
 
@@ -340,7 +340,7 @@ jobs:
 
       - name: Install uv
         if: ${{ !contains(runner.name, 'arc-runner') }}
-        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           enable-cache: true
 

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -151,7 +151,7 @@ jobs:
       will-publish: ${{ steps.predict.outputs.will-publish }}
       next-version: ${{ steps.predict.outputs.version }}
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           ref: ${{ inputs.tag || github.ref }}
           fetch-depth: 0  # full history — semantic-release dry-run reads it
@@ -179,11 +179,11 @@ jobs:
       github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           fetch-depth: 0
       - name: Install uv
-        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           enable-cache: false
       - name: Validate commit messages
@@ -202,13 +202,13 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           ref: ${{ inputs.tag || github.ref }}
 
       - name: Install uv
         if: ${{ !contains(runner.name, 'arc-runner') }}
-        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           enable-cache: true
 
@@ -257,13 +257,13 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           ref: ${{ inputs.tag || github.ref }}
 
       - name: Install uv
         if: ${{ !contains(runner.name, 'arc-runner') }}
-        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           enable-cache: true
 
@@ -302,7 +302,7 @@ jobs:
     if: needs.plan.outputs.run-build == 'true'
     runs-on: ${{ startsWith(github.head_ref || github.ref_name, 'renovate/') && (vars.GH_RUNNER_RENOVATE || 'ubuntu-latest') || (inputs.runner-mode || vars.GH_RUNNER_MODE) == 'free' && 'ubuntu-latest' || inputs.runner-build || vars.GH_RUNNER_PYTHON || vars.GH_RUNNER_DEFAULT || 'ubuntu-latest' }}
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           ref: ${{ inputs.tag || github.ref }}
 
@@ -340,7 +340,7 @@ jobs:
 
       - name: Install uv
         if: ${{ !contains(runner.name, 'arc-runner') }}
-        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           enable-cache: true
 

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -167,7 +167,7 @@ jobs:
       next-version: ${{ steps.predict.outputs.version }}
       build-matrix: ${{ steps.matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           ref: ${{ inputs.tag || github.ref }}
           fetch-depth: 0  # full history — semantic-release dry-run reads it
@@ -213,11 +213,11 @@ jobs:
       github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           fetch-depth: 0
       - name: Install uv
-        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           enable-cache: false
       - name: Validate commit messages
@@ -237,7 +237,7 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           ref: ${{ inputs.tag || github.ref }}
 
@@ -248,7 +248,7 @@ jobs:
 
       - name: Install Rust toolchain
         if: ${{ !contains(runner.name, 'arc-runner') }}
-        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
         with:
           toolchain: ${{ inputs.rust-toolchain }}
           components: clippy, rustfmt
@@ -307,7 +307,7 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           ref: ${{ inputs.tag || github.ref }}
 
@@ -318,7 +318,7 @@ jobs:
 
       - name: Install Rust toolchain
         if: ${{ !contains(runner.name, 'arc-runner') }}
-        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
         with:
           toolchain: ${{ inputs.rust-toolchain }}
 
@@ -360,7 +360,7 @@ jobs:
     strategy:
       matrix: ${{ fromJson(needs.plan.outputs.build-matrix) }}
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           ref: ${{ inputs.tag || github.ref }}
 
@@ -410,7 +410,7 @@ jobs:
 
       - name: Install Rust toolchain
         if: ${{ !contains(runner.name, 'arc-runner') }}
-        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
         with:
           toolchain: ${{ inputs.rust-toolchain }}
 

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -167,7 +167,7 @@ jobs:
       next-version: ${{ steps.predict.outputs.version }}
       build-matrix: ${{ steps.matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.tag || github.ref }}
           fetch-depth: 0  # full history — semantic-release dry-run reads it
@@ -213,11 +213,11 @@ jobs:
       github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
       - name: Install uv
-        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           enable-cache: false
       - name: Validate commit messages
@@ -237,7 +237,7 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.tag || github.ref }}
 
@@ -255,7 +255,7 @@ jobs:
 
       - name: Cache cargo
         if: ${{ !contains(runner.name, 'arc-runner') }}
-        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           # NOT ~/.cargo/bin/ in THIS job: it only ever held cargo-audit /
           # cargo-deny, which now arrive pinned from setup-rust-tools into
@@ -307,7 +307,7 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.tag || github.ref }}
 
@@ -324,7 +324,7 @@ jobs:
 
       - name: Cache cargo
         if: ${{ !contains(runner.name, 'arc-runner') }}
-        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             ~/.cargo/bin/
@@ -360,7 +360,7 @@ jobs:
     strategy:
       matrix: ${{ fromJson(needs.plan.outputs.build-matrix) }}
     steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.tag || github.ref }}
 
@@ -416,7 +416,7 @@ jobs:
 
       - name: Cache cargo
         if: ${{ !contains(runner.name, 'arc-runner') }}
-        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             ~/.cargo/bin/

--- a/.github/workflows/ts-ci.yml
+++ b/.github/workflows/ts-ci.yml
@@ -148,7 +148,7 @@ jobs:
       will-publish: ${{ steps.predict.outputs.will-publish }}
       next-version: ${{ steps.predict.outputs.version }}
     steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.tag || github.ref }}
           fetch-depth: 0
@@ -176,11 +176,11 @@ jobs:
       github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
       - name: Install uv
-        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           enable-cache: false
       - name: Validate commit messages
@@ -199,19 +199,19 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.tag || github.ref }}
 
       - name: Set up Node.js
         if: ${{ !contains(runner.name, 'arc-runner') }}
-        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ inputs.node-version }}
 
       - name: Install uv
         if: ${{ !contains(runner.name, 'arc-runner') }}
-        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           enable-cache: false
 
@@ -261,19 +261,19 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.tag || github.ref }}
 
       - name: Set up Node.js
         if: ${{ !contains(runner.name, 'arc-runner') }}
-        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ inputs.node-version }}
 
       - name: Install uv
         if: ${{ !contains(runner.name, 'arc-runner') }}
-        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           enable-cache: false
 
@@ -314,7 +314,7 @@ jobs:
     if: needs.plan.outputs.run-build == 'true'
     runs-on: ${{ startsWith(github.head_ref || github.ref_name, 'renovate/') && (vars.GH_RUNNER_RENOVATE || 'ubuntu-latest') || (inputs.runner-mode || vars.GH_RUNNER_MODE) == 'free' && 'ubuntu-latest' || inputs.runner-build || vars.GH_RUNNER_TYPESCRIPT || vars.GH_RUNNER_DEFAULT || 'ubuntu-latest' }}
     steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.tag || github.ref }}
 
@@ -348,13 +348,13 @@ jobs:
 
       - name: Set up Node.js
         if: ${{ !contains(runner.name, 'arc-runner') }}
-        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ inputs.node-version }}
 
       - name: Install uv
         if: ${{ !contains(runner.name, 'arc-runner') }}
-        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           enable-cache: false
 

--- a/.github/workflows/ts-ci.yml
+++ b/.github/workflows/ts-ci.yml
@@ -148,7 +148,7 @@ jobs:
       will-publish: ${{ steps.predict.outputs.will-publish }}
       next-version: ${{ steps.predict.outputs.version }}
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           ref: ${{ inputs.tag || github.ref }}
           fetch-depth: 0
@@ -176,11 +176,11 @@ jobs:
       github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           fetch-depth: 0
       - name: Install uv
-        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           enable-cache: false
       - name: Validate commit messages
@@ -199,19 +199,19 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           ref: ${{ inputs.tag || github.ref }}
 
       - name: Set up Node.js
         if: ${{ !contains(runner.name, 'arc-runner') }}
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: ${{ inputs.node-version }}
 
       - name: Install uv
         if: ${{ !contains(runner.name, 'arc-runner') }}
-        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           enable-cache: false
 
@@ -261,19 +261,19 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           ref: ${{ inputs.tag || github.ref }}
 
       - name: Set up Node.js
         if: ${{ !contains(runner.name, 'arc-runner') }}
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: ${{ inputs.node-version }}
 
       - name: Install uv
         if: ${{ !contains(runner.name, 'arc-runner') }}
-        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           enable-cache: false
 
@@ -314,7 +314,7 @@ jobs:
     if: needs.plan.outputs.run-build == 'true'
     runs-on: ${{ startsWith(github.head_ref || github.ref_name, 'renovate/') && (vars.GH_RUNNER_RENOVATE || 'ubuntu-latest') || (inputs.runner-mode || vars.GH_RUNNER_MODE) == 'free' && 'ubuntu-latest' || inputs.runner-build || vars.GH_RUNNER_TYPESCRIPT || vars.GH_RUNNER_DEFAULT || 'ubuntu-latest' }}
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           ref: ${{ inputs.tag || github.ref }}
 
@@ -348,13 +348,13 @@ jobs:
 
       - name: Set up Node.js
         if: ${{ !contains(runner.name, 'arc-runner') }}
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: ${{ inputs.node-version }}
 
       - name: Install uv
         if: ${{ !contains(runner.name, 'arc-runner') }}
-        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           enable-cache: false
 

--- a/config/versions.yaml
+++ b/config/versions.yaml
@@ -18,25 +18,27 @@
 #   --apply         rewrite workflows + composites to match this file
 #   --fix           --apply + non-zero exit on change (pre-commit hook)
 #   --latest        report newest release >= 7 days old per action
-#   --auto-update   bump to those, test on ci-test-* projects, commit/revert
+#   --auto-update   bump to those, validate LOCALLY, revert on failure. It
+#                   does not commit and does not trigger remote CI - the
+#                   ci-test-* fleet validates on the PR.
 
 # GitHub Actions — SHA-pinned, 7-day cooldown (see _select_pinned_release)
 actions:
   checkout:
-    version: v6.1.0
-    sha: d23441a48e516b6c34aea4fa41551a30e30af803
+    version: v7.0.1
+    sha: 3d3c42e5aac5ba805825da76410c181273ba90b1
   setup-node:
-    version: v6.5.0
-    sha: 249970729cb0ef3589644e2896645e5dc5ba9c38
+    version: v7.0.0
+    sha: 820762786026740c76f36085b0efc47a31fe5020
   setup-go:
-    version: v6.5.0
-    sha: 924ae3a1cded613372ab5595356fb5720e22ba16
+    version: v7.0.0
+    sha: b7ad1dad31e06c5925ef5d2fc7ad053ef454303e
   setup-uv:
-    version: v8.3.2
-    sha: 11f9893b081a58869d3b5fccaea48c9e9e46f990
+    version: v9.0.0
+    sha: c771a70e6277c0a99b617c7a806ffedaca235ff9
   cache:
-    version: v5.1.0
-    sha: caa296126883cff596d87d8935842f9db880ef25
+    version: v6.1.0
+    sha: 55cc8345863c7cc4c66a329aec7e433d2d1c52a9
   # Branch ref (dtolnay/rust-toolchain has no semver releases): pinned to
   # the newest master commit >= 7 days old. The toolchain itself is chosen
   # by the `with: toolchain:` input, not by the ref.
@@ -65,15 +67,18 @@ actions:
 
 # External CLI tools hyperi-ci installs at CI time.
 #
-# Same 7-day cooldown as actions above, and the same "a breaking bump is a
-# human edit" rule - but the clamp follows semver's COMPATIBILITY axis, which
-# is not always the major (see _compat_clamp):
-#   1.x+  clamp the major   - gitleaks v8 -> v9 never auto-lands. That is
-#         precisely the breaking-CLI case that produced #64 (`detect` removed).
-#   0.x   clamp major AND minor - under semver §4, 0.20 -> 0.21 is itself a
-#         breaking bump. cargo-deny (0.20.2) and cargo-audit (v0.22.2) are 0.x,
-#         so clamping only the major there would wave through the breaking axis
-#         while blocking the safe 1.0.0 move.
+# Same 7-day cooldown as actions above, and majors are eligible the same way.
+# There is no compatibility clamp: holding a major back meant the estate sat
+# on an old one until somebody made the manual edit, and nobody did.
+#
+# What that trades away is real, so know it. gitleaks v8 -> v9 can now
+# auto-land, and a breaking CLI change is exactly what produced #64 (`detect`
+# removed). For the 0.x tools - cargo-deny (0.20.2), cargo-audit (v0.22.2) -
+# semver 4 makes the MINOR the breaking axis, so 0.20 -> 0.21 auto-lands too.
+#
+# The safety net is CI, not the clamp: every bump goes through a PR and the
+# ci-test-* fleet exercises these tools for real. A tool whose flags moved
+# shows up as a red quality stage there.
 #
 # `pin:` names the file that MIRRORS this version, because these tools are
 # consumed from Python / composite-action source rather than a `uses:` line.

--- a/config/versions.yaml
+++ b/config/versions.yaml
@@ -23,17 +23,17 @@
 # GitHub Actions — SHA-pinned, 7-day cooldown (see _select_pinned_release)
 actions:
   checkout:
-    version: v6.0.3
-    sha: df4cb1c069e1874edd31b4311f1884172cec0e10
+    version: v6.1.0
+    sha: d23441a48e516b6c34aea4fa41551a30e30af803
   setup-node:
-    version: v6.4.0
-    sha: 48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+    version: v6.5.0
+    sha: 249970729cb0ef3589644e2896645e5dc5ba9c38
   setup-go:
     version: v6.5.0
     sha: 924ae3a1cded613372ab5595356fb5720e22ba16
   setup-uv:
-    version: v8.2.0
-    sha: fac544c07dec837d0ccb6301d7b5580bf5edae39
+    version: v8.3.2
+    sha: 11f9893b081a58869d3b5fccaea48c9e9e46f990
   cache:
     version: v5.1.0
     sha: caa296126883cff596d87d8935842f9db880ef25
@@ -42,7 +42,7 @@ actions:
   # by the `with: toolchain:` input, not by the ref.
   rust-toolchain:
     version: master
-    sha: fa04a1451ff1842e2626ccb99004d0195b455a88
+    sha: 2c7215f132e9ebf062739d9130488b56d53c060c
   upload-artifact:
     version: v7.0.1
     sha: 043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
@@ -60,8 +60,8 @@ actions:
   # packages + attestation referrers safely (snok's README warns
   # against multi-platform use); verified maintained 2026-07.
   ghcr-cleanup:
-    version: v1.0.16
-    sha: cd0cdb900b5dbf3a6f2cc869f0dbb0b8211f50c4
+    version: v1.2.2
+    sha: d52806a0dc70b430571a37da1fde39733ffd640f
 
 # External CLI tools hyperi-ci installs at CI time.
 #
@@ -124,10 +124,8 @@ tools:
     version: v2.12.2
     repo: golangci/golangci-lint
     pin: .github/actions/setup-go-tools/action.yml
-  # NOT v2.28.0: published 2026-07-14, still inside the 7-day cooldown. The
-  # cooldown applies to our own pins too, not just to what --auto-update picks.
   gosec:
-    version: v2.27.1
+    version: v2.28.0
     repo: securego/gosec
     pin: .github/actions/setup-go-tools/action.yml
   # No prebuilt binaries upstream (golang/vuln releases carry no assets), so

--- a/scripts/update-versions.py
+++ b/scripts/update-versions.py
@@ -21,7 +21,10 @@ Usage:
 
 Update behaviour:
   - Actions resolve to the newest release that has aged past the 7-day
-    cooldown, within the current major (major bumps are a manual edit).
+    cooldown, MAJORS INCLUDED. Actions are SHA-pinned and every consumer runs
+    the full pipeline against them, so a breaking major surfaces as a red CI
+    run rather than a silent behaviour change. Holding majors back had its own
+    cost: the estate split across majors while nobody made the manual edit.
   - Branch refs (rust-toolchain@master) pin the newest master commit >=7d old.
   - Runtimes (python, node, rust) require explicit update — never auto-bumped.
   - --auto-update applies the bumps then validates LOCALLY (YAML re-parse,
@@ -228,9 +231,9 @@ def _select_pinned_release(
     (e.g. download-artifact `v3.1.0-node20`) with recent dates, so ordering
     by publish date picks the wrong one. Skips drafts, prereleases,
     non-semver tags, and — timestamp-required posture — anything without a
-    `published_at`. With `major` set, stays within that major so a surprise
-    major bump never auto-lands (those are a deliberate edit). With `minor`
-    set, also stays within that minor — see _compat_clamp for why 0.x needs it.
+    `published_at`. The optional `major` / `minor` clamps restrict the
+    candidate range; callers leave them unset, so majors are eligible and a
+    breaking bump is caught by CI on the PR rather than blocked here.
     Returns the chosen release dict or None.
     """
     cutoff = now - timedelta(days=cooldown_days)
@@ -254,26 +257,6 @@ def _select_pinned_release(
         if best_ver is None or ver > best_ver:
             best_ver, best = ver, rel
     return best
-
-
-def _compat_clamp(version: str) -> tuple[int | None, int | None]:
-    """Return the (major, minor) clamp that keeps an auto-bump compatible.
-
-    For 1.0.0+ the major is the compatibility axis, so clamping the major is
-    enough. For **0.x the MINOR is the compatibility axis** (semver §4: anything
-    may change at any time; 0.20 -> 0.21 is a breaking bump), so clamping only
-    the major there is exactly backwards - it BLOCKS the safe 0.20.2 -> 1.0.0
-    move while WAVING THROUGH the breaking 0.20 -> 0.21 one.
-
-    cargo-deny (0.20.2) and cargo-audit (v0.22.2) are both 0.x, so this is live,
-    not theoretical.
-    """
-    parsed = _parse_semver(version)
-    if parsed is None:
-        return None, None
-    if parsed[0] == 0:
-        return 0, parsed[1]
-    return parsed[0], None
 
 
 def _gh_json(path: str) -> Any:
@@ -355,10 +338,15 @@ def _pinned_spec_for(short_name: str, current: object, now: datetime) -> dict | 
     if not isinstance(releases, list):
         return None
     releases = cast("list[dict[str, Any]]", releases)
-    # Stay within the current major — major bumps are a deliberate edit.
-    cur_semver = _parse_semver(str(cur_version)) if cur_version else None
-    major = cur_semver[0] if cur_semver else None
-    chosen = _select_pinned_release(releases, now, major=major)
+    # Majors included. Actions are pinned to a SHA and every consumer runs the
+    # full pipeline against them, so a breaking major shows up as a red CI run
+    # on a PR rather than as a silent behaviour change - and holding a major
+    # back has its own cost, which is the estate splitting across majors while
+    # nobody gets round to the manual edit.
+    #
+    # The cooldown still applies, so a major has to be a week old before it is
+    # eligible. What catches an actual incompatibility is CI, not this clamp.
+    chosen = _select_pinned_release(releases, now)
     if not chosen:
         return None
     tag = chosen["tag_name"]
@@ -858,8 +846,11 @@ def _latest_tool_release(spec: dict, now: datetime) -> tuple[str | None, str]:
         return None, "lookup-failed"
     releases = _tool_releases(spec, releases)
     cur = _parse_semver(str(cur_version))
-    clamp_major, clamp_minor = _compat_clamp(str(cur_version))
-    best = _select_pinned_release(releases, now, major=clamp_major, minor=clamp_minor)
+    # No compatibility clamp. Same reasoning as actions: the cooldown still
+    # gates freshness, and a tool whose flags changed across a major shows up
+    # as a red quality stage on a PR. Clamping meant the estate quietly sat on
+    # an old major until someone made the manual edit, which nobody did.
+    best = _select_pinned_release(releases, now)
     if not best:
         return None, "no-candidate"
     tag = best.get("tag_name")
@@ -916,10 +907,11 @@ def _set_tool_version_in_yaml(text: str, name: str, version: str) -> str:
 def _auto_update(versions: dict) -> int:
     """Auto-update actions + semantic-release, validate locally, revert on fail.
 
-    Actions resolve to the newest release past the 7-day cooldown, within
-    their current major (major bumps stay a manual edit). Runtimes never
-    auto-bump. Validation is LOCAL (see _validate_locally) — remote E2E is
-    the branch-mode rehearsal's job, not this script's.
+    Actions resolve to the newest release past the 7-day cooldown, majors
+    included. Runtimes never auto-bump. Validation is LOCAL (see
+    _validate_locally) — remote E2E is the branch-mode rehearsal's job, not
+    this script's, so a major that breaks at RUNTIME is caught by CI on the
+    PR, not here.
     """
     print("Auto-update: resolving releases past the cooldown...\n")
     now = datetime.now(UTC)

--- a/src/hyperi_ci/bootstrap.py
+++ b/src/hyperi_ci/bootstrap.py
@@ -1,0 +1,461 @@
+# Project:   HyperI CI
+# File:      src/hyperi_ci/bootstrap.py
+# Purpose:   Install language toolchains (Rust, Go, Node) for a runner image
+#
+# License:   BUSL-1.1 - HYPERI PTY LIMITED
+# Copyright: (c) 2026 HYPERI PTY LIMITED
+"""Install the language toolchains a runner image pre-bakes.
+
+Separate from `native_deps` because these come from vendor channels (rustup,
+go.dev, nvm) rather than apt, and because hyperi-ci does NOT install them per
+job -- it assumes they exist. `languages/rust/build.py` calls `rustup target
+add` with no bootstrap behind it.
+
+That assumption is exactly why baking them pays: the cargo tools are source
+builds costing tens of minutes cold, and nothing reinstalls them over the top.
+The linters are the opposite case and are deliberately not here.
+
+Every step is idempotent -- an already-present toolchain is left alone, so a
+rebuild over a warm cache is cheap and a partial failure can be re-run.
+
+Linux only. No-ops elsewhere, so importing this on a macOS workstation is
+safe but does nothing useful.
+"""
+
+from __future__ import annotations
+
+import os
+import platform
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import yaml
+from scalo import logger
+
+_CONFIG_FILE = Path(__file__).resolve().parent / "config" / "bootstrap.yaml"
+
+# Vendor install channels. Not configurable: changing where Rust comes from is
+# not a knob, it is a different decision entirely.
+_RUSTUP_URL = "https://sh.rustup.rs"
+_GO_VERSION_URL = "https://go.dev/VERSION?m=text"
+_GO_DOWNLOAD_BASE = "https://go.dev/dl"
+_NVM_INSTALL_BASE = "https://raw.githubusercontent.com/nvm-sh/nvm"
+_CARGO_BINSTALL_URL = (
+    "https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh"
+)
+
+
+@dataclass
+class RustSpec:
+    """What to install for Rust."""
+
+    channels: list[str] = field(default_factory=lambda: ["stable"])
+    components: list[str] = field(default_factory=list)
+    targets: list[str] = field(default_factory=list)
+    cargo_tools: list[str] = field(default_factory=list)
+
+
+@dataclass
+class NodeSpec:
+    """Node majors to preload via nvm, and which is default on PATH."""
+
+    versions: list[str] = field(default_factory=list)
+    default: str = ""
+
+
+def _is_linux() -> bool:
+    return platform.system() == "Linux"
+
+
+def _sudo_prefix() -> list[str]:
+    """`sudo` when non-root, nothing when already root.
+
+    A Dockerfile RUN executes as root with no sudo configured, which would
+    otherwise fail with 'root is not in the sudoers file'.
+    """
+    if not _is_linux():
+        return []
+    return [] if os.geteuid() == 0 else ["sudo"]
+
+
+def _run(cmd: list[str], *, shell_input: str | None = None) -> int:
+    """Run a command, streaming output. Returns the exit code."""
+    logger.info(f"  $ {' '.join(cmd)}")
+    result = subprocess.run(
+        cmd,
+        input=shell_input,
+        text=True if shell_input is not None else False,
+        encoding="utf-8" if shell_input is not None else None,
+        errors="replace" if shell_input is not None else None,
+        check=False,
+    )
+    return result.returncode
+
+
+def _capture(cmd: list[str]) -> tuple[int, str]:
+    """Run a command and capture stdout. Returns (exit code, stdout)."""
+    result = subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        check=False,
+    )
+    return result.returncode, result.stdout.strip()
+
+
+def _have(binary: str) -> bool:
+    return shutil.which(binary) is not None
+
+
+def load_spec() -> tuple[RustSpec, bool, NodeSpec]:
+    """Read bootstrap.yaml into (rust, go_enabled, node)."""
+    with _CONFIG_FILE.open(encoding="utf-8") as fh:
+        raw = yaml.safe_load(fh) or {}
+
+    rust_raw = raw.get("rust", {}) or {}
+    node_raw = raw.get("node", {}) or {}
+    go_enabled = bool((raw.get("go", {}) or {}).get("enabled", False))
+
+    rust = RustSpec(
+        channels=[str(c) for c in rust_raw.get("channels", ["stable"])],
+        components=[str(c) for c in rust_raw.get("components", [])],
+        targets=[str(t) for t in rust_raw.get("targets", [])],
+        cargo_tools=[str(t) for t in rust_raw.get("cargo_tools", [])],
+    )
+    node = NodeSpec(
+        versions=[str(v) for v in node_raw.get("versions", [])],
+        default=str(node_raw.get("default", "")),
+    )
+    return rust, go_enabled, node
+
+
+# ---------------------------------------------------------------------------
+# Rust
+# ---------------------------------------------------------------------------
+
+
+def _install_cargo_tools(tools: list[str]) -> int:
+    """Install cargo binaries, preferring prebuilt releases.
+
+    `cargo install` compiles from source: sccache, cargo-deny, cargo-audit and
+    cargo-nextest together are tens of minutes. All four publish prebuilt
+    binaries, so cargo-binstall fetches those instead and the image build drops
+    to minutes. Falls back to a source build per tool if binstall is
+    unavailable or a fetch fails -- slow, but the image is still correct.
+    """
+    if not tools:
+        return 0
+
+    if not _have("cargo-binstall"):
+        logger.info("Installing cargo-binstall (prebuilt cargo tool fetcher)")
+        # The installer script is fetched and piped to a shell. Upstream ships
+        # no signed artefact for it; the alternative is a source build of
+        # binstall itself, which defeats the point.
+        dl = subprocess.run(
+            ["curl", "-fsSL", _CARGO_BINSTALL_URL],
+            capture_output=True,
+            check=False,
+        )
+        if dl.returncode == 0 and dl.stdout:
+            rc = subprocess.run(["bash"], input=dl.stdout, check=False).returncode
+            if rc != 0:
+                logger.warning("cargo-binstall install failed - falling back to source builds")
+        else:
+            logger.warning("cargo-binstall download failed - falling back to source builds")
+
+    failed: list[str] = []
+    for tool in tools:
+        binary = tool
+        if _have(binary):
+            logger.info(f"[{tool}] already installed")
+            continue
+
+        installed = False
+        if _have("cargo-binstall"):
+            logger.info(f"Installing {tool} (prebuilt)")
+            installed = _run(["cargo", "binstall", "--no-confirm", tool]) == 0
+            if not installed:
+                logger.warning(f"[{tool}] binstall failed - building from source")
+
+        if not installed:
+            logger.info(f"Installing {tool} (source build)")
+            installed = _run(["cargo", "install", tool, "--locked"]) == 0
+
+        if not installed:
+            failed.append(tool)
+
+    if failed:
+        logger.error(f"cargo tools failed to install: {failed}")
+        return 1
+    return 0
+
+
+def install_rust(spec: RustSpec) -> int:
+    """Install rustup, the requested channels, components, targets and tools.
+
+    Honours RUSTUP_HOME / CARGO_HOME if the caller set them (a runner image
+    puts them on a shared path so every job sees the same toolchain).
+    """
+    if not _is_linux():
+        logger.info("Skipping Rust bootstrap on non-Linux")
+        return 0
+
+    default_channel = spec.channels[0] if spec.channels else "stable"
+
+    if _have("rustup"):
+        logger.info("rustup already installed")
+    else:
+        logger.info("Installing rustup")
+        dl = subprocess.run(
+            ["curl", "--proto", "=https", "--tlsv1.2", "-sSf", _RUSTUP_URL],
+            capture_output=True,
+            check=False,
+        )
+        if dl.returncode != 0 or not dl.stdout:
+            logger.error("Failed to download rustup installer")
+            return dl.returncode or 1
+        rc = subprocess.run(
+            ["sh", "-s", "--", "-y", "--default-toolchain", default_channel],
+            input=dl.stdout,
+            check=False,
+        ).returncode
+        if rc != 0:
+            logger.error("rustup install failed")
+            return rc
+
+    # rustup drops binaries in CARGO_HOME/bin, which is not on PATH yet in the
+    # same process. Add it so the calls below resolve.
+    cargo_home = Path(os.environ.get("CARGO_HOME", str(Path.home() / ".cargo")))
+    cargo_bin = cargo_home / "bin"
+    if str(cargo_bin) not in os.environ.get("PATH", "").split(os.pathsep):
+        os.environ["PATH"] = f"{cargo_bin}{os.pathsep}{os.environ.get('PATH', '')}"
+
+    for channel in spec.channels:
+        rc = _run(["rustup", "toolchain", "install", channel])
+        if rc != 0:
+            logger.error(f"rustup toolchain install {channel} failed")
+            return rc
+
+    if spec.components:
+        rc = _run(["rustup", "component", "add", *spec.components])
+        if rc != 0:
+            logger.error(f"rustup component add failed: {spec.components}")
+            return rc
+
+    for target in spec.targets:
+        rc = _run(["rustup", "target", "add", target])
+        if rc != 0:
+            logger.error(f"rustup target add {target} failed")
+            return rc
+
+    return _install_cargo_tools(spec.cargo_tools)
+
+
+# ---------------------------------------------------------------------------
+# Go
+# ---------------------------------------------------------------------------
+
+
+def install_go() -> int:
+    """Install the current Go stable release into /usr/local/go.
+
+    go.dev publishes the current stable version as plain text, so there is no
+    version to pin here -- the image tracks stable and is rolled back by
+    re-tagging rather than by pinning.
+    """
+    if not _is_linux():
+        logger.info("Skipping Go bootstrap on non-Linux")
+        return 0
+
+    if Path("/usr/local/go/bin/go").exists():
+        logger.info("Go already installed at /usr/local/go")
+        return 0
+
+    rc, version = _capture(["curl", "-fsSL", _GO_VERSION_URL])
+    if rc != 0 or not version:
+        logger.error("Failed to resolve the current Go version")
+        return rc or 1
+    # The endpoint returns e.g. "go1.26.0\ntime ..." -- first line, minus "go"
+    version = version.splitlines()[0].strip().removeprefix("go")
+    logger.info(f"Installing Go {version}")
+
+    arch = "arm64" if platform.machine() in ("aarch64", "arm64") else "amd64"
+    tarball = f"go{version}.linux-{arch}.tar.gz"
+    dest = Path("/tmp") / tarball  # noqa: S108 - transient download, removed below
+
+    rc = _run(["curl", "-fsSL", "-o", str(dest), f"{_GO_DOWNLOAD_BASE}/{tarball}"])
+    if rc != 0:
+        logger.error(f"Failed to download {tarball}")
+        return rc
+
+    rc = _run([*_sudo_prefix(), "tar", "-C", "/usr/local", "-xzf", str(dest)])
+    dest.unlink(missing_ok=True)
+    if rc != 0:
+        logger.error("Failed to extract the Go tarball")
+        return rc
+
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Node
+# ---------------------------------------------------------------------------
+
+
+def install_node(spec: NodeSpec) -> int:
+    """Install nvm and preload every requested Node major.
+
+    Why nvm rather than NodeSource: NodeSource ships one Node per system.
+    Carrying every active LTS lets repos pin via .nvmrc or engines.node
+    without `actions/setup-node` re-downloading Node on every job.
+
+    Why the majors are installed with --latest-npm: `npm install -g npm@latest`
+    over an existing npm leaves a broken dependency tree
+    (MODULE_NOT_FOUND: promise-retry). nvm does the upgrade atomically during
+    install instead.
+    """
+    if not _is_linux():
+        logger.info("Skipping Node bootstrap on non-Linux")
+        return 0
+    if not spec.versions:
+        logger.info("No Node versions requested")
+        return 0
+
+    nvm_dir = Path(os.environ.get("NVM_DIR", "/usr/local/nvm"))
+    default = spec.default or spec.versions[-1]
+
+    if not (nvm_dir / "nvm.sh").exists():
+        rc, tag = _capture(
+            [
+                "curl",
+                "-fsSL",
+                "https://api.github.com/repos/nvm-sh/nvm/releases/latest",
+            ]
+        )
+        if rc != 0 or not tag:
+            logger.error("Failed to resolve the current nvm release")
+            return rc or 1
+        import json
+
+        try:
+            nvm_tag = json.loads(tag)["tag_name"]
+        except (ValueError, KeyError):
+            logger.error("Could not parse the nvm release response")
+            return 1
+
+        logger.info(f"Installing nvm {nvm_tag} into {nvm_dir}")
+        nvm_dir.mkdir(parents=True, exist_ok=True)
+        dl = subprocess.run(
+            ["curl", "-fsSL", f"{_NVM_INSTALL_BASE}/{nvm_tag}/install.sh"],
+            capture_output=True,
+            check=False,
+        )
+        if dl.returncode != 0 or not dl.stdout:
+            logger.error("Failed to download the nvm installer")
+            return dl.returncode or 1
+        env = {**os.environ, "NVM_DIR": str(nvm_dir)}
+        rc = subprocess.run(
+            ["bash"], input=dl.stdout, env=env, check=False
+        ).returncode
+        if rc != 0:
+            logger.error("nvm install failed")
+            return rc
+
+    # nvm is a shell function, not a binary -- every call has to source it.
+    installs = " && ".join(
+        f'nvm install "{v}" --latest-npm' for v in spec.versions
+    )
+    script = (
+        f'export NVM_DIR="{nvm_dir}"\n'
+        f'. "$NVM_DIR/nvm.sh"\n'
+        f"{installs} && "
+        f'nvm alias default "{default}" && '
+        f"nvm cache clear\n"
+        # Symlink the default major onto PATH so a job that never sources nvm
+        # still finds node/npm/npx/corepack.
+        f'DEFAULT_BIN="$NVM_DIR/versions/node/$(nvm version default)/bin"\n'
+        f'for b in node npm npx corepack; do ln -sf "$DEFAULT_BIN/$b" '
+        f'"/usr/local/bin/$b"; done\n'
+    )
+    logger.info(f"Installing Node majors: {spec.versions} (default {default})")
+    rc = subprocess.run(["bash", "-c", script], check=False).returncode
+    if rc != 0:
+        logger.error("Node install failed")
+        return rc
+
+    # Written so an interactive shell on the runner also gets nvm.
+    profile = Path("/etc/profile.d/nvm.sh")
+    try:
+        profile.write_text(
+            f'export NVM_DIR="{nvm_dir}"\n'
+            '[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"\n'
+            '[ -s "$NVM_DIR/bash_completion" ] && . "$NVM_DIR/bash_completion"\n',
+            encoding="utf-8",
+            newline="\n",
+        )
+    except OSError as exc:
+        logger.warning(f"Could not write {profile}: {exc}")
+
+    if _have("corepack"):
+        _run(["corepack", "enable", "pnpm"])
+
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def install_toolchain_bootstrap() -> int:
+    """Install every language toolchain in bootstrap.yaml. Returns exit code."""
+    if not _is_linux():
+        logger.info(f"Skipping toolchain bootstrap on {platform.system()}")
+        return 0
+
+    rust, go_enabled, node = load_spec()
+
+    logger.info("=== toolchain bootstrap: Rust ===")
+    rc = install_rust(rust)
+    if rc != 0:
+        return rc
+
+    if go_enabled:
+        logger.info("=== toolchain bootstrap: Go ===")
+        rc = install_go()
+        if rc != 0:
+            return rc
+
+    logger.info("=== toolchain bootstrap: Node ===")
+    rc = install_node(node)
+    if rc != 0:
+        return rc
+
+    logger.info("Toolchain bootstrap complete")
+    return 0
+
+
+def print_bootstrap_plan() -> None:
+    """Print what the bootstrap would install (dry-run helper).
+
+    stderr, matching `native_deps.print_needed`, so the two interleave in
+    install order rather than splitting across streams.
+    """
+    rust, go_enabled, node = load_spec()
+    out = sys.stderr
+    print("  rust:", file=out)
+    print(f"    channels:    {', '.join(rust.channels) or '-'}", file=out)
+    print(f"    components:  {', '.join(rust.components) or '-'}", file=out)
+    print(f"    targets:     {', '.join(rust.targets) or '-'}", file=out)
+    print(f"    cargo tools: {', '.join(rust.cargo_tools) or '-'}", file=out)
+    print(f"  go: {'current stable' if go_enabled else 'disabled'}", file=out)
+    print(
+        f"  node: {', '.join(node.versions) or '-'} "
+        f"(default {node.default or '-'})",
+        file=out,
+    )

--- a/src/hyperi_ci/bootstrap.py
+++ b/src/hyperi_ci/bootstrap.py
@@ -43,9 +43,7 @@ _RUSTUP_URL = "https://sh.rustup.rs"
 _GO_VERSION_URL = "https://go.dev/VERSION?m=text"
 _GO_DOWNLOAD_BASE = "https://go.dev/dl"
 _NVM_INSTALL_BASE = "https://raw.githubusercontent.com/nvm-sh/nvm"
-_CARGO_BINSTALL_URL = (
-    "https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh"
-)
+_CARGO_BINSTALL_URL = "https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh"
 
 
 @dataclass
@@ -164,9 +162,13 @@ def _install_cargo_tools(tools: list[str]) -> int:
         if dl.returncode == 0 and dl.stdout:
             rc = subprocess.run(["bash"], input=dl.stdout, check=False).returncode
             if rc != 0:
-                logger.warning("cargo-binstall install failed - falling back to source builds")
+                logger.warning(
+                    "cargo-binstall install failed - falling back to source builds"
+                )
         else:
-            logger.warning("cargo-binstall download failed - falling back to source builds")
+            logger.warning(
+                "cargo-binstall download failed - falling back to source builds"
+            )
 
     failed: list[str] = []
     for tool in tools:
@@ -359,17 +361,13 @@ def install_node(spec: NodeSpec) -> int:
             logger.error("Failed to download the nvm installer")
             return dl.returncode or 1
         env = {**os.environ, "NVM_DIR": str(nvm_dir)}
-        rc = subprocess.run(
-            ["bash"], input=dl.stdout, env=env, check=False
-        ).returncode
+        rc = subprocess.run(["bash"], input=dl.stdout, env=env, check=False).returncode
         if rc != 0:
             logger.error("nvm install failed")
             return rc
 
     # nvm is a shell function, not a binary -- every call has to source it.
-    installs = " && ".join(
-        f'nvm install "{v}" --latest-npm' for v in spec.versions
-    )
+    installs = " && ".join(f'nvm install "{v}" --latest-npm' for v in spec.versions)
     script = (
         f'export NVM_DIR="{nvm_dir}"\n'
         f'. "$NVM_DIR/nvm.sh"\n'
@@ -455,7 +453,6 @@ def print_bootstrap_plan() -> None:
     print(f"    cargo tools: {', '.join(rust.cargo_tools) or '-'}", file=out)
     print(f"  go: {'current stable' if go_enabled else 'disabled'}", file=out)
     print(
-        f"  node: {', '.join(node.versions) or '-'} "
-        f"(default {node.default or '-'})",
+        f"  node: {', '.join(node.versions) or '-'} (default {node.default or '-'})",
         file=out,
     )

--- a/src/hyperi_ci/cli.py
+++ b/src/hyperi_ci/cli.py
@@ -698,6 +698,14 @@ def install_all_cmd(
             "--dry-run", "-n", help="Show what would be installed without installing"
         ),
     ] = False,
+    skip_toolchains: Annotated[
+        bool,
+        typer.Option(
+            "--skip-toolchains",
+            help="Skip the language toolchain bootstrap (rustup, Go, Node) and "
+            "install only the apt-sourced deps.",
+        ),
+    ] = False,
 ) -> None:
     """Install everything hyperi-ci might need, for a runner image bake.
 
@@ -715,14 +723,17 @@ def install_all_cmd(
     stay install-on-demand so baking a default cannot lock out a job needing a
     different version.
 
-    Not covered here: the language toolchains themselves (rustup, Go, Node).
-    A runner image bootstraps those separately.
+    Covers three things, in order: the language toolchains from
+    `config/bootstrap.yaml` (rustup, Go, Node), the multi-version apt families
+    from `config/toolchains/`, then every language's `config/native-deps/`.
 
     Examples:
-        hyperi-ci install-all              # bake everything
-        hyperi-ci install-all --dry-run    # show the plan
+        hyperi-ci install-all                   # bake everything
+        hyperi-ci install-all --dry-run         # show the plan
+        hyperi-ci install-all --skip-toolchains # apt deps only
 
     """
+    from hyperi_ci.bootstrap import install_toolchain_bootstrap, print_bootstrap_plan
     from hyperi_ci.native_deps import _NATIVE_DEPS_DIR, _TOOLCHAINS_DIR, print_needed
     from hyperi_ci.native_deps import install_native_deps as _install
 
@@ -736,6 +747,18 @@ def install_all_cmd(
     if not plan:
         typer.echo("install-all found no toolchain or native-deps config", err=True)
         raise typer.Exit(1)
+
+    # Language toolchains first: the apt families below include BOLT and the
+    # cross-compilers that a Rust build then links against.
+    if not skip_toolchains:
+        typer.echo("install-all: language toolchains", err=True)
+        if dry_run:
+            print_bootstrap_plan()
+        else:
+            rc = install_toolchain_bootstrap()
+            if rc != 0:
+                typer.echo(f"install-all failed on toolchains (exit {rc})", err=True)
+                raise typer.Exit(rc)
 
     for category, name in plan:
         typer.echo(f"install-all: {category}/{name}", err=True)

--- a/src/hyperi_ci/cli.py
+++ b/src/hyperi_ci/cli.py
@@ -571,8 +571,11 @@ def logs(
 def install_native_deps(
     language: Annotated[
         str,
-        typer.Argument(help="Language (rust, typescript, golang, python)"),
-    ],
+        typer.Argument(
+            help="Language (rust, typescript, golang, python). "
+            "Defaults to 'all' = every language.",
+        ),
+    ] = "all",
     project_dir: Annotated[
         str | None,
         typer.Option("--project-dir", "-C", help="Project root directory"),
@@ -592,16 +595,34 @@ def install_native_deps(
         ),
     ] = False,
 ) -> None:
-    """Detect and install native system dependencies for a language."""
+    """Detect and install native system dependencies for a language.
+
+    Examples:
+        hyperi-ci install-native-deps --all        # bake every language
+        hyperi-ci install-native-deps rust --all   # bake only Rust
+        hyperi-ci install-native-deps              # CI-time: conditional
+        hyperi-ci install-native-deps rust         # CI-time: Rust if triggered
+
+    """
+    from hyperi_ci.native_deps import _NATIVE_DEPS_DIR, print_needed
     from hyperi_ci.native_deps import install_native_deps as _install
-    from hyperi_ci.native_deps import print_needed
 
     dir_path = Path(project_dir) if project_dir else None
-    if dry_run:
-        print_needed(language, project_dir=dir_path, all_mode=all_mode)
-        return
-    rc = _install(language, project_dir=dir_path, all_mode=all_mode)
-    raise typer.Exit(rc)
+
+    # `all` fans out to every language YAML in config/native-deps/, matching
+    # the install-toolchains contract so the two commands behave alike.
+    if language == "all":
+        languages = sorted(f.stem for f in _NATIVE_DEPS_DIR.glob("*.yaml"))
+    else:
+        languages = [language]
+
+    for lang in languages:
+        if dry_run:
+            print_needed(lang, project_dir=dir_path, all_mode=all_mode)
+            continue
+        rc = _install(lang, project_dir=dir_path, all_mode=all_mode)
+        if rc != 0:
+            raise typer.Exit(rc)
 
 
 @app.command(name="install-toolchains")
@@ -666,6 +687,66 @@ def install_toolchains(
             fam, project_dir=dir_path, category="toolchains", all_mode=all_mode
         )
         if rc != 0:
+            raise typer.Exit(rc)
+
+
+@app.command(name="install-all")
+def install_all_cmd(
+    dry_run: Annotated[
+        bool,
+        typer.Option(
+            "--dry-run", "-n", help="Show what would be installed without installing"
+        ),
+    ] = False,
+) -> None:
+    """Install everything hyperi-ci might need, for a runner image bake.
+
+    Every toolchain family and every language's native deps, unconditionally --
+    no manifest matching, because an image is built without a project in front
+    of it. This is the ONE command a runner image Dockerfile calls.
+
+    Why it exists: a pre-baked tool only pays off if it is what hyperi-ci would
+    have installed anyway. Anything else gets skipped as already-present (and
+    so silently overrides the pinned version) or reinstalled over the top (and
+    so wasted the image build). Baking BY this command keeps the image and the
+    CI-time install path the same code, so they cannot drift.
+
+    Entries marked `bake: false` are excluded -- non-coinstallable toolsets
+    stay install-on-demand so baking a default cannot lock out a job needing a
+    different version.
+
+    Not covered here: the language toolchains themselves (rustup, Go, Node).
+    A runner image bootstraps those separately.
+
+    Examples:
+        hyperi-ci install-all              # bake everything
+        hyperi-ci install-all --dry-run    # show the plan
+
+    """
+    from hyperi_ci.native_deps import _NATIVE_DEPS_DIR, _TOOLCHAINS_DIR, print_needed
+    from hyperi_ci.native_deps import install_native_deps as _install
+
+    plan: list[tuple[str, str]] = [
+        ("toolchains", f.stem) for f in sorted(_TOOLCHAINS_DIR.glob("*.yaml"))
+    ]
+    plan += [
+        ("native-deps", f.stem) for f in sorted(_NATIVE_DEPS_DIR.glob("*.yaml"))
+    ]
+
+    if not plan:
+        typer.echo("install-all found no toolchain or native-deps config", err=True)
+        raise typer.Exit(1)
+
+    for category, name in plan:
+        typer.echo(f"install-all: {category}/{name}", err=True)
+        if dry_run:
+            print_needed(name, category=category, all_mode=True)
+            continue
+        rc = _install(name, category=category, all_mode=True)
+        if rc != 0:
+            typer.echo(
+                f"install-all failed on {category}/{name} (exit {rc})", err=True
+            )
             raise typer.Exit(rc)
 
 

--- a/src/hyperi_ci/cli.py
+++ b/src/hyperi_ci/cli.py
@@ -740,9 +740,7 @@ def install_all_cmd(
     plan: list[tuple[str, str]] = [
         ("toolchains", f.stem) for f in sorted(_TOOLCHAINS_DIR.glob("*.yaml"))
     ]
-    plan += [
-        ("native-deps", f.stem) for f in sorted(_NATIVE_DEPS_DIR.glob("*.yaml"))
-    ]
+    plan += [("native-deps", f.stem) for f in sorted(_NATIVE_DEPS_DIR.glob("*.yaml"))]
 
     if not plan:
         typer.echo("install-all found no toolchain or native-deps config", err=True)
@@ -767,9 +765,7 @@ def install_all_cmd(
             continue
         rc = _install(name, category=category, all_mode=True)
         if rc != 0:
-            typer.echo(
-                f"install-all failed on {category}/{name} (exit {rc})", err=True
-            )
+            typer.echo(f"install-all failed on {category}/{name} (exit {rc})", err=True)
             raise typer.Exit(rc)
 
 

--- a/src/hyperi_ci/config/bootstrap.yaml
+++ b/src/hyperi_ci/config/bootstrap.yaml
@@ -1,0 +1,60 @@
+# Project:   HyperI CI
+# File:      src/hyperi_ci/config/bootstrap.yaml
+# Purpose:   Language toolchain bootstrap for runner image bake
+#
+# License:   BUSL-1.1 - HYPERI PTY LIMITED
+# Copyright: (c) 2026 HYPERI PTY LIMITED
+#
+# The language runtimes a runner image pre-installs. Distinct from
+# native-deps (apt system libraries) and toolchains (LLVM/GCC apt families):
+# these are the compilers themselves, installed from vendor channels rather
+# than apt.
+#
+# WHY THESE ARE BAKED AND THE LINTERS ARE NOT
+#
+# A pre-baked tool only pays off if it is what would have been installed
+# anyway. The linters fail that test - hyperi-ci reinstalls them per job, so
+# baking them is either wasted or a silent override of a pinned version.
+#
+# These pass it, because hyperi-ci does NOT install them per job: it assumes
+# they are already there (`rust/build.py` calls `rustup target add`). And they
+# are expensive - the cargo tools below are SOURCE builds, tens of minutes on
+# a cold runner. Paying that once per image instead of once per job is the
+# reason a pre-built runner image exists at all.
+#
+# NO VERSIONS HERE, DELIBERATELY. Channels and majors, not point releases.
+# The image is rebuilt on a cadence and rolled back by re-tagging, so it
+# tracks current rather than pinning. What IS listed is the stuff that is a
+# capacity or compatibility decision rather than a version bump.
+
+rust:
+  # stable for builds, nightly for the fmt/lint features some repos use.
+  channels:
+    - stable
+    - nightly
+  components:
+    - clippy
+    - rustfmt
+  # Cross-compilation targets to preinstall. arm64 release builds need this.
+  targets:
+    - aarch64-unknown-linux-gnu
+  # Installed with cargo-binstall where a prebuilt release exists, falling
+  # back to `cargo install --locked`. All four publish binaries, so the
+  # common path avoids a source build each.
+  cargo_tools:
+    - sccache
+    - cargo-audit
+    - cargo-deny
+    - cargo-nextest
+
+go:
+  enabled: true
+
+node:
+  # Every active LTS, so repos can pin via .nvmrc without setup-node
+  # re-downloading per job. Adding a major is a capacity decision - the image
+  # carries every one listed.
+  versions:
+    - "20"
+    - "22"
+  default: "22"

--- a/tests/unit/test_bootstrap.py
+++ b/tests/unit/test_bootstrap.py
@@ -1,0 +1,122 @@
+# Project:   HyperI CI
+# File:      tests/unit/test_bootstrap.py
+# Purpose:   Tests for the runner-image language toolchain bootstrap
+#
+# License:   BUSL-1.1 - HYPERI PTY LIMITED
+# Copyright: (c) 2026 HYPERI PTY LIMITED
+"""Tests for `hyperi_ci.bootstrap`.
+
+The install paths themselves are Linux-only and shell out to rustup / go.dev /
+nvm, so they are exercised for real by a runner image build, not here. What is
+tested here is everything that can be checked without a Linux box: the config
+contract, the non-Linux guard, and the CLI wiring.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+import pytest
+
+from hyperi_ci import bootstrap
+
+_TEST_ENV = {**os.environ, "HYPERCI_AUTO_UPDATE": "false"}
+
+
+class TestLoadSpec:
+    """The bootstrap.yaml contract."""
+
+    def test_parses_shipped_config(self) -> None:
+        rust, go_enabled, node = bootstrap.load_spec()
+
+        # stable must come first -- it is the rustup default-toolchain.
+        assert rust.channels[0] == "stable"
+        assert "nightly" in rust.channels
+        assert {"clippy", "rustfmt"} <= set(rust.components)
+        assert "aarch64-unknown-linux-gnu" in rust.targets
+        assert go_enabled is True
+        assert node.default in node.versions
+
+    def test_cargo_tools_are_the_expensive_source_builds(self) -> None:
+        """These four are why the image exists -- they compile from source.
+
+        If one is dropped from the config, jobs pay that build cost per run,
+        which is the regression the pre-built image was created to avoid.
+        """
+        rust, _, _ = bootstrap.load_spec()
+        assert {"sccache", "cargo-audit", "cargo-deny", "cargo-nextest"} <= set(
+            rust.cargo_tools
+        )
+
+
+class TestNonLinuxGuard:
+    """Every install path no-ops off Linux rather than half-running."""
+
+    @pytest.mark.skipif(
+        sys.platform.startswith("linux"),
+        reason="asserts the non-Linux branch; on Linux these really install",
+    )
+    def test_all_installers_noop(self) -> None:
+        rust, _, node = bootstrap.load_spec()
+        assert bootstrap.install_rust(rust) == 0
+        assert bootstrap.install_go() == 0
+        assert bootstrap.install_node(node) == 0
+        assert bootstrap.install_toolchain_bootstrap() == 0
+
+    def test_sudo_prefix_empty_off_linux(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(bootstrap.platform, "system", lambda: "Darwin")
+        assert bootstrap._sudo_prefix() == []
+
+    def test_sudo_prefix_empty_as_root(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A Dockerfile RUN is root with no sudo configured."""
+        monkeypatch.setattr(bootstrap.platform, "system", lambda: "Linux")
+        monkeypatch.setattr(bootstrap.os, "geteuid", lambda: 0)
+        assert bootstrap._sudo_prefix() == []
+
+    def test_sudo_prefix_used_when_non_root(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(bootstrap.platform, "system", lambda: "Linux")
+        monkeypatch.setattr(bootstrap.os, "geteuid", lambda: 1001)
+        assert bootstrap._sudo_prefix() == ["sudo"]
+
+
+class TestInstallAllWiring:
+    """install-all covers toolchains as well as apt deps."""
+
+    def _run(self, *args: str, cwd) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [sys.executable, "-m", "hyperi_ci.cli", "install-all", *args],
+            capture_output=True,
+            text=True,
+            cwd=str(cwd),
+            env=_TEST_ENV,
+        )
+
+    def test_dry_run_includes_toolchain_plan(self, tmp_path) -> None:
+        result = self._run("--dry-run", cwd=tmp_path)
+        assert result.returncode == 0
+        combined = result.stdout + result.stderr
+        assert "language toolchains" in combined
+        assert "cargo tools:" in combined
+        assert "sccache" in combined
+
+    def test_toolchains_planned_before_apt_deps(self, tmp_path) -> None:
+        """Ordering matters: the apt families include BOLT and the
+        cross-compilers a Rust build then links against."""
+        result = self._run("--dry-run", cwd=tmp_path)
+        assert result.returncode == 0
+        combined = result.stdout + result.stderr
+        assert combined.index("language toolchains") < combined.index(
+            "native-deps/rust"
+        )
+
+    def test_skip_toolchains_excludes_them(self, tmp_path) -> None:
+        result = self._run("--dry-run", "--skip-toolchains", cwd=tmp_path)
+        assert result.returncode == 0
+        combined = result.stdout + result.stderr
+        assert "language toolchains" not in combined
+        # the apt side still runs
+        assert "native-deps/rust" in combined

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -114,3 +114,76 @@ class TestCLI:
         # JSON output has quoted keys and braces
         assert '"language"' in result.stdout
         assert "{" in result.stdout
+
+
+class TestRunnerImageBake:
+    """The commands a runner image Dockerfile calls to pre-bake tooling.
+
+    A pre-baked tool only pays off if it is exactly what hyperi-ci would have
+    installed anyway -- otherwise it is either skipped as already-present
+    (silently overriding the pinned version) or reinstalled over the top
+    (wasting the image build). These cover the fan-out that makes baking BY
+    hyperi-ci possible.
+    """
+
+    def test_install_all_dry_run_covers_both_categories(self, tmp_path) -> None:
+        result = subprocess.run(
+            [sys.executable, "-m", "hyperi_ci.cli", "install-all", "--dry-run"],
+            capture_output=True,
+            text=True,
+            cwd=str(tmp_path),
+            env=_TEST_ENV,
+        )
+        assert result.returncode == 0
+        combined = result.stdout + result.stderr
+        # Every toolchain family AND every native-deps language, because an
+        # image is built with no project in front of it.
+        for expected in (
+            "toolchains/llvm",
+            "toolchains/gcc",
+            "native-deps/rust",
+            "native-deps/golang",
+            "native-deps/python",
+            "native-deps/typescript",
+        ):
+            assert expected in combined, f"install-all skipped {expected}"
+
+    def test_install_all_excludes_bake_false_entries(self, tmp_path) -> None:
+        """`bake: false` stays install-on-demand even in a full bake.
+
+        Non-coinstallable toolsets declare Conflicts, so baking one version
+        would lock out jobs needing another.
+        """
+        result = subprocess.run(
+            [sys.executable, "-m", "hyperi_ci.cli", "install-all", "--dry-run"],
+            capture_output=True,
+            text=True,
+            cwd=str(tmp_path),
+            env=_TEST_ENV,
+        )
+        assert result.returncode == 0
+        combined = result.stdout + result.stderr
+        assert "llvm-non-coinstallable: skip" in combined
+
+    def test_install_native_deps_defaults_to_every_language(self, tmp_path) -> None:
+        """Bare `install-native-deps --all` fans out, matching install-toolchains."""
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "hyperi_ci.cli",
+                "install-native-deps",
+                "--all",
+                "--dry-run",
+            ],
+            capture_output=True,
+            text=True,
+            cwd=str(tmp_path),
+            env=_TEST_ENV,
+        )
+        assert result.returncode == 0
+        combined = result.stdout + result.stderr
+        # rust.yaml and typescript.yaml both carry entries -- seeing both
+        # proves the fan-out rather than a single default language.
+        assert "mold linker" in combined
+        assert "sharp / image processing" in combined


### PR DESCRIPTION
The ARC runner image bakes tools that hyperi-ci then installs anyway. Turns out that is worse than just wasteful.

install_ci_binary() opens with shutil.which() and returns early if the binary is already there - so a baked gitleaks or hadolint silently overrides the version hyperi-ci pinned, AND skips the fail-closed SHA256 check on the download. Meanwhile setup-go-tools deliberately has no short-circuit, so the golangci-lint/gosec/govulncheck we bake get built at image time and overwritten on every job.

The fix is to stop copying the list and build the image BY hyperi-ci instead. Then what is baked is what would have been installed, by construction.

- install-all: every toolchain family plus every language's native deps, unconditionally. One command for a Dockerfile to call. bake: false entries stay excluded so non-coinstallable toolsets do not lock out jobs needing another version.
- install-native-deps now defaults to all and fans out, same as install-toolchains already did. It was the odd one out needing an explicit argument.

Most of the machinery was already here - all_mode, the bake flag, _sudo_prefix handling root in a Dockerfile. The docstrings already said 'runner image bake'. This just finishes the wiring.

Done when: hyperi-infra's runner images build from install-all instead of their own tool list.

Verified: install-all --dry-run plans 39 dep groups across gcc 13/14, llvm 19-22 and all four languages, and excludes llvm-non-coinstallable. 43 tests pass across test_cli.py + test_native_deps.py, 3 of them new.