### PR TITLE
fix(runners): document the runner vocabulary the fleet actually serves

### DIFF
--- a/config/runners.yaml
+++ b/config/runners.yaml
@@ -27,26 +27,31 @@
 #   size   4cpu      matches the stock GitHub ubuntu runner
 #          16cpu     the step up
 #
-# Every deployed shape is ALSO reachable by a single label, because an org
-# variable holds one string and not an array. Both sizes exist for every type,
-# so no type name is unambiguous on its own and each set carries a compound
-# handle:
+# A JOB ADDRESSES A SCALE SET BY NAME, and the name states both axes:
 #
-#   default         vanilla 4cpu   — what a repo gets when it asks for nothing
-#   vanilla-4cpu    vanilla 4cpu   — the same set, named explicitly
-#   vanilla-16cpu   vanilla 16cpu  — grunt without the compiler estate
-#   native-4cpu     native 4cpu    — a hyperi-ci project that is not Rust or
-#                                    C++: it wants the pre-baked toolchain,
-#                                    not sixteen cores to run ruff
-#   native-16cpu    native 16cpu   — Rust and C++
-#   debian-4cpu     debian 4cpu    — .deb packaging
-#   debian-16cpu    debian 16cpu   — .deb packaging that needs the cores
+#   arc-vanilla-4cpu    what a repo gets when it asks for nothing
+#   arc-vanilla-16cpu   grunt without the compiler estate
+#   arc-native-4cpu     a hyperi-ci project that is not Rust or C++: it wants
+#                       the pre-baked toolchain, not sixteen cores to run ruff
+#   arc-native-16cpu    Rust and C++
+#   arc-debian-4cpu     .deb packaging
+#   arc-debian-16cpu    .deb packaging that needs the cores
 #
-# GH_RUNNER_CPP is set org-wide to `native-16cpu`. Nothing in this repo reads
-# it yet — there is no C++ reusable workflow, only the LLVM and GCC toolchains
-# the native image bakes — so a C++ job names it in `runs-on` directly. It is
-# declared now so the answer is already agreed when that workflow lands, rather
-# than someone picking a runner ad hoc.
+# Not by label, and that is measured rather than assumed: a `runs-on` naming a
+# LABEL queues forever with the listener reporting `assigned job=0`, while the
+# same job naming the scale set spawns runner pods in seconds. GitHub holds the
+# scale set registration server-side and the listener reconnects to it, so the
+# labels on the Kubernetes resource are not what a job matches against.
+#
+# The practical consequence: a `runs-on` value must be one of the names above,
+# exactly. Anything else matches nothing and the job queues SILENTLY -- it does
+# not fail, it waits, which is a far worse thing to debug.
+#
+# GH_RUNNER_CPP is set org-wide to `arc-native-16cpu`. Nothing in this repo
+# reads it yet — there is no C++ reusable workflow, only the LLVM and GCC
+# toolchains the native image bakes — so a C++ job names it in `runs-on`
+# directly. It is declared now so the answer is already agreed when that
+# workflow lands, rather than someone picking a runner ad hoc.
 #
 # The native image is ~21 GB either way, so prefer a vanilla set when nothing
 # in the compiler estate is actually needed.
@@ -63,8 +68,8 @@ runners:
   build:
     amd64:
       # Rust builds want the compiler estate and the cores: GH_RUNNER_RUST
-      # points at `native-16cpu`. Falls back through GH_RUNNER_DEFAULT
-      # (`default`) to the hosted runner only if neither variable exists.
+      # points at `arc-native-16cpu`. Falls back through GH_RUNNER_DEFAULT
+      # (`arc-vanilla-4cpu`) to the hosted runner only if neither exists.
       default: ubuntu-latest
       org_var: GH_RUNNER_RUST
       fallback_var: GH_RUNNER_DEFAULT

--- a/config/runners.yaml
+++ b/config/runners.yaml
@@ -11,19 +11,52 @@
 # Consumer projects never reference runners directly — they inherit from
 # the reusable workflow which reads org variables and falls back to these
 # defaults.
+#
+# THE RUNNER VOCABULARY
+#
+# The self-hosted fleet is ARC scale sets carrying two label axes:
+#
+#   type   what is in the image
+#          vanilla   stock runner + internal CA + docker CLI + uv. Fast start.
+#          native    vanilla plus the compiler estate — rustup with stable and
+#                    nightly, the cargo tools, Go, Node, LLVM/GCC, the aarch64
+#                    cross toolchain, and the shared sccache/crate cache.
+#          debian    vanilla, on Debian Trixie. For .deb builds, which have to
+#                    happen on the distro they target. Carries no toolchain.
+#
+#   size   4cpu      matches the stock GitHub ubuntu runner
+#          16cpu     the step up
+#
+# Every deployed shape is ALSO reachable by a single label, because an org
+# variable holds one string and not an array:
+#
+#   default         vanilla 4cpu   — what a repo gets when it asks for nothing
+#   vanilla-16cpu   vanilla 16cpu  — grunt without the compiler estate
+#   native          native 16cpu   — Rust and C++
+#   debian          debian 4cpu    — .deb packaging
+#
+# A `runs-on` naming a combination that is not deployed matches nothing and the
+# job queues silently forever, so stay inside this list. The full matrix lives
+# in hyperi-infra `ansible/playbooks/k8s-arc-runners.yml`.
+#
+# `ubuntu-latest` remains the last-resort literal below. It is only reached
+# when the org variable is unset — with GH_RUNNER_DEFAULT set, every repo gets
+# a self-hosted runner without asking.
 
 runners:
   build:
     amd64:
-      # ARC self-hosted runners (fast, cached, 16cpu)
-      # Fallback chain: input > org var > default
+      # Rust builds want the compiler estate and the cores: GH_RUNNER_RUST
+      # points at `native`. Falls back through GH_RUNNER_DEFAULT (`default`)
+      # to the hosted runner only if neither variable exists.
       default: ubuntu-latest
       org_var: GH_RUNNER_RUST
       fallback_var: GH_RUNNER_DEFAULT
 
     arm64:
-      # GitHub native arm64 runners (no cross-compile needed)
-      # Swap to ARC arm64 later via GH_RUNNER_ARM64 org variable
+      # GitHub native arm64 runners (no cross-compile needed).
+      # The native image does carry the aarch64 cross toolchain, so this could
+      # move to an ARC arm64 scale set — none is deployed today.
       default: ubuntu-24.04-arm
       org_var: GH_RUNNER_ARM64
 

--- a/config/runners.yaml
+++ b/config/runners.yaml
@@ -28,12 +28,22 @@
 #          16cpu     the step up
 #
 # Every deployed shape is ALSO reachable by a single label, because an org
-# variable holds one string and not an array:
+# variable holds one string and not an array. Both sizes exist for every type,
+# so no type name is unambiguous on its own and each set carries a compound
+# handle:
 #
 #   default         vanilla 4cpu   — what a repo gets when it asks for nothing
+#   vanilla-4cpu    vanilla 4cpu   — the same set, named explicitly
 #   vanilla-16cpu   vanilla 16cpu  — grunt without the compiler estate
-#   native          native 16cpu   — Rust and C++
-#   debian          debian 4cpu    — .deb packaging
+#   native-4cpu     native 4cpu    — a hyperi-ci project that is not Rust or
+#                                    C++: it wants the pre-baked toolchain,
+#                                    not sixteen cores to run ruff
+#   native-16cpu    native 16cpu   — Rust and C++
+#   debian-4cpu     debian 4cpu    — .deb packaging
+#   debian-16cpu    debian 16cpu   — .deb packaging that needs the cores
+#
+# The native image is ~21 GB either way, so prefer a vanilla set when nothing
+# in the compiler estate is actually needed.
 #
 # A `runs-on` naming a combination that is not deployed matches nothing and the
 # job queues silently forever, so stay inside this list. The full matrix lives
@@ -47,8 +57,8 @@ runners:
   build:
     amd64:
       # Rust builds want the compiler estate and the cores: GH_RUNNER_RUST
-      # points at `native`. Falls back through GH_RUNNER_DEFAULT (`default`)
-      # to the hosted runner only if neither variable exists.
+      # points at `native-16cpu`. Falls back through GH_RUNNER_DEFAULT
+      # (`default`) to the hosted runner only if neither variable exists.
       default: ubuntu-latest
       org_var: GH_RUNNER_RUST
       fallback_var: GH_RUNNER_DEFAULT

--- a/config/runners.yaml
+++ b/config/runners.yaml
@@ -42,6 +42,12 @@
 #   debian-4cpu     debian 4cpu    — .deb packaging
 #   debian-16cpu    debian 16cpu   — .deb packaging that needs the cores
 #
+# GH_RUNNER_CPP is set org-wide to `native-16cpu`. Nothing in this repo reads
+# it yet — there is no C++ reusable workflow, only the LLVM and GCC toolchains
+# the native image bakes — so a C++ job names it in `runs-on` directly. It is
+# declared now so the answer is already agreed when that workflow lands, rather
+# than someone picking a runner ad hoc.
+#
 # The native image is ~21 GB either way, so prefer a vanilla set when nothing
 # in the compiler estate is actually needed.
 #

--- a/docs/lessons.md
+++ b/docs/lessons.md
@@ -224,10 +224,14 @@ username convention and rejects it with "Wrong username was used" (401).
 **Correct invocation:**
 ```python
 cmd = [
-    "uv", "publish",
-    "--publish-url", org.pypi_publish_url,
-    "--username", os.environ.get("JFROG_USERNAME", "_token"),
-    "--password", os.environ["JFROG_TOKEN"],
+    "uv",
+    "publish",
+    "--publish-url",
+    org.pypi_publish_url,
+    "--username",
+    os.environ.get("JFROG_USERNAME", "_token"),
+    "--password",
+    os.environ["JFROG_TOKEN"],
 ]
 ```
 


### PR DESCRIPTION
The ARC fleet was rebuilt around three image types and two sizes, and nothing in here recorded what a repo should actually set its runner variables to. runners.yaml said "ARC self-hosted runners (fast, cached, 16cpu)" and left the reader to guess.

**A job addresses a scale set by NAME, not by label.** That is measured on the cluster, not assumed: a job whose `runs-on` named a label queued forever while the listener reported `assigned job=0`; the same job naming the scale set spawned runner pods within seconds and went green. GitHub holds the scale set registration server-side and the listener reconnects to it, so labels on the Kubernetes resource are not what a job matches against.

The names carry both axes anyway:

    arc-vanilla-4cpu    what a repo gets when it asks for nothing
    arc-vanilla-16cpu   grunt without the compiler estate
    arc-native-4cpu     a hyperi-ci project that is not Rust or C++
    arc-native-16cpu    Rust and C++
    arc-debian-4cpu     .deb packaging
    arc-debian-16cpu    .deb packaging that needs the cores

`arc-native-4cpu` is not a contradiction - plenty of the projects hyperi-ci supports are neither Rust nor C++, and a Python job still wants the pre-baked toolchain, it just does not want sixteen cores to run ruff. The native image is ~21 GB either way, so vanilla stays the right answer when nothing in the compiler estate is needed.

`GH_RUNNER_CPP` is forward-documented. Nothing here reads it - there is no C++ reusable workflow, only the LLVM and GCC toolchains the native image bakes - so a C++ job names `arc-native-16cpu` directly. Declared now so the answer is agreed before that workflow lands.

Worth writing down because the failure mode is nasty: a `runs-on` that is not one of these names matches NOTHING and the job queues silently. It does not fail, it waits.

Also folds in a ruff format fix for a Python block in docs/lessons.md, which was failing the quality gate and blocking every push regardless of content.

Verified: full Rust CI green on `arc-native-16cpu` - Test, Quality and the amd64 Build all ran on ARC pods.

Fleet matrix lives in hyperi-io/hyperi-infra#49.