### PR TITLE
fix(upgrade): stop reporting an upgrade that did not happen

### DIFF
--- a/docs/deployment/tiers.md
+++ b/docs/deployment/tiers.md
@@ -219,7 +219,9 @@ into an invalid state.
 
 **"contract declares schema_version=N but this hyperi-ci supports up to M"**
 Your contract was emitted by a newer producer than this hyperi-ci.
-Run `uv tool upgrade hyperi-ci` (or `hyperi-ci upgrade`) and retry.
+Run `hyperi-ci upgrade` (or `uv tool install --force hyperi-ci@latest`) and
+retry. Prefer either of those over `uv tool upgrade`, which silently declines on
+an install pinned to an exact version.
 
 **"Generate (Tier 3): emit-artefacts: artefact templater is not yet implemented"**
 Expected until Phase 2 ships.

--- a/docs/migration/onboarding.md
+++ b/docs/migration/onboarding.md
@@ -58,8 +58,11 @@ semantics. The biggest user-visible changes:
 2. **Bump `hyperi-ci` to >= 2.0.0** in any local install:
 
    ```bash
-   uv tool upgrade hyperi-ci
+   uv tool install --force hyperi-ci@latest
    ```
+
+   Not `uv tool upgrade` -- it exits 0 without doing anything if the install was
+   ever pinned to an exact version.
 
 3. **Update reusable workflow ref** in your `.github/workflows/ci.yml`:
 

--- a/src/hyperi_ci/upgrade.py
+++ b/src/hyperi_ci/upgrade.py
@@ -17,14 +17,16 @@ import time
 import urllib.request
 from pathlib import Path
 
-from packaging.version import Version
+from packaging.version import InvalidVersion, Version
 from scalo.logger import logger
 
 from hyperi_ci import __version__
 from hyperi_ci.common import is_ci
 
-PYPI_URL = "https://pypi.org/pypi/hyperi-ci/json"
+PACKAGE = "hyperi-ci"
+PYPI_URL = f"https://pypi.org/pypi/{PACKAGE}/json"
 PYPI_TIMEOUT = 5
+SUBPROCESS_TIMEOUT = 30
 CACHE_DIR = Path.home() / ".cache" / "hyperi-ci"
 TIMESTAMP_FILE = CACHE_DIR / "last-update-check"
 CHECK_INTERVAL = 4 * 60 * 60  # 4 hours in seconds
@@ -69,6 +71,13 @@ def _build_upgrade_cmd(
 ) -> list[str]:
     """Build the subprocess command for upgrading hyperi-ci.
 
+    The unpinned uv path uses ``tool install --force ...@latest`` rather than
+    ``tool upgrade``. ``tool upgrade`` refuses to act on an install whose receipt
+    carries an exact version, and refusing is how it reports that -- exit 0 with
+    "Nothing to upgrade". So one ``upgrade --version`` in the past would have
+    disabled every upgrade after it. ``@latest`` both moves the version and
+    clears the pin, which is uv's own advice in that message.
+
     Args:
         uv_path: Path to uv binary, or None to use pip.
         version: Specific version to install, or None for latest.
@@ -80,19 +89,115 @@ def _build_upgrade_cmd(
     """
     if uv_path:
         if version:
-            return [uv_path, "tool", "install", "--force", f"hyperi-ci=={version}"]
-        cmd = [uv_path, "tool", "upgrade"]
+            return [uv_path, "tool", "install", "--force", f"{PACKAGE}=={version}"]
+        cmd = [uv_path, "tool", "install", "--force"]
         if pre:
             cmd.append("--prerelease=allow")
-        cmd.append("hyperi-ci")
+        cmd.append(f"{PACKAGE}@latest")
         return cmd
 
     cmd = [sys.executable, "-m", "pip", "install", "--upgrade"]
     if pre and not version:
         cmd.append("--pre")
-    pkg = f"hyperi-ci=={version}" if version else "hyperi-ci"
+    pkg = f"{PACKAGE}=={version}" if version else PACKAGE
     cmd.append(pkg)
     return cmd
+
+
+def _parse_installed_version(output: str, *, from_uv: bool) -> str | None:
+    """Pull the installed hyperi-ci version out of uv or pip output.
+
+    Args:
+        output: stdout of ``uv tool list`` or ``pip show hyperi-ci``.
+        from_uv: True when parsing uv output, False for pip.
+
+    Returns:
+        Version string, or None if the package was not found in the output.
+
+    """
+    for raw in output.splitlines():
+        line = raw.strip()
+        if from_uv:
+            # `uv tool list` prints one line per tool -- "hyperi-ci v2.9.5" --
+            # followed by its entrypoints indented with "- ". Only the tool line
+            # carries the version, and the entrypoint shares the tool's name, so
+            # the "v" separator is what distinguishes them.
+            if line.startswith(f"{PACKAGE} v"):
+                return line.split(" v", 1)[1].strip()
+        elif line.lower().startswith("version:"):
+            return line.split(":", 1)[1].strip()
+    return None
+
+
+def _installed_version(uv_path: str | None) -> str | None:
+    """Read the version installed on disk, not the one currently running.
+
+    A process that upgrades itself still has the old ``__version__`` imported, so
+    it cannot use that to confirm anything landed. Ask the installer.
+
+    Args:
+        uv_path: Path to uv binary, or None to ask pip.
+
+    Returns:
+        Installed version string, or None if it could not be determined.
+
+    """
+    cmd = (
+        [uv_path, "tool", "list"]
+        if uv_path
+        else [sys.executable, "-m", "pip", "show", PACKAGE]
+    )
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            check=False,
+            timeout=SUBPROCESS_TIMEOUT,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if result.returncode != 0:
+        return None
+    return _parse_installed_version(result.stdout, from_uv=bool(uv_path))
+
+
+def _confirm_upgraded(uv_path: str | None, target: str) -> bool:
+    """Check the installed version actually reached target.
+
+    Exit code 0 is not evidence of an upgrade. ``uv tool upgrade`` exits 0 when it
+    declines to do anything, so the old code logged a version bump that had not
+    happened, wrote the freshness timestamp, and suppressed the next check.
+
+    Args:
+        uv_path: Path to uv binary, or None for pip.
+        target: Version the upgrade was aiming at.
+
+    Returns:
+        True if the installed version is now at or past target.
+
+    """
+    installed = _installed_version(uv_path)
+    if installed is None:
+        logger.warning(
+            "Upgrade command succeeded but the installed version could not be "
+            "read, so the upgrade is unconfirmed"
+        )
+        return False
+    try:
+        moved = Version(installed) >= Version(target)
+    except InvalidVersion:
+        logger.warning(f"Installed version is not parseable: {installed}")
+        return False
+    if not moved:
+        logger.warning(
+            f"Upgrade did not take effect -- still on {installed}, wanted {target}. "
+            f"If this install is pinned, reinstall with: "
+            f"uv tool install --force {PACKAGE}@latest"
+        )
+    return moved
 
 
 def _timestamp_age() -> float:
@@ -241,7 +346,19 @@ def run_upgrade(
         logger.error(f"Upgrade failed (exit {rc})")
         return rc
 
-    logger.info(f"hyperi-ci upgraded: {current} -> {target}")
+    if not _confirm_upgraded(uv_path, target):
+        return 1
+
+    if version and uv_path:
+        # An explicit --version is a deliberate act, so honour it -- but say out
+        # loud what it costs, because uv records it as an exact pin and every
+        # later auto-update will decline without explaining why.
+        logger.warning(
+            f"Pinned to {target}. Auto-updates will not move off it. "
+            f"To go back to tracking latest: hyperi-ci upgrade"
+        )
+
+    logger.info(f"{PACKAGE} upgraded: {current} -> {target}")
     _re_exec()
     return 0  # unreachable after execvpe, keeps type checker happy
 
@@ -275,8 +392,14 @@ def maybe_auto_update() -> None:
             logger.warning(f"Auto-update failed (exit {rc})")
             return
 
+        if not _confirm_upgraded(uv_path, stable):
+            # Deliberately no timestamp. Writing one here is what let a stuck
+            # install go quiet for four hours at a time, so leave the check due
+            # and let the next invocation try again and warn again.
+            return
+
         _write_timestamp()
-        logger.info(f"hyperi-ci upgraded: {current} -> {stable}")
+        logger.info(f"{PACKAGE} upgraded: {current} -> {stable}")
         _re_exec()
 
     except Exception as exc:

--- a/tests/unit/test_upgrade.py
+++ b/tests/unit/test_upgrade.py
@@ -9,15 +9,22 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
 import sys
 import time
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
+from packaging.version import Version
+
 from hyperi_ci.upgrade import (
     CHECK_INTERVAL,
     _build_upgrade_cmd,
+    _confirm_upgraded,
     _fetch_pypi_versions,
+    _installed_version,
+    _parse_installed_version,
     _parse_latest_version,
     _run_upgrade_cmd,
     _should_auto_update,
@@ -64,9 +71,17 @@ class TestParseLatestVersion:
 class TestBuildUpgradeCmd:
     """Build the correct upgrade command based on install method."""
 
-    def test_uv_latest(self) -> None:
+    def test_uv_latest_uses_at_latest_not_tool_upgrade(self) -> None:
+        """`tool upgrade` no-ops on a pinned receipt; `@latest` clears the pin."""
         cmd = _build_upgrade_cmd(uv_path="/usr/bin/uv", version=None, pre=False)
-        assert cmd == ["/usr/bin/uv", "tool", "upgrade", "hyperi-ci"]
+        assert cmd == [
+            "/usr/bin/uv",
+            "tool",
+            "install",
+            "--force",
+            "hyperi-ci@latest",
+        ]
+        assert "upgrade" not in cmd
 
     def test_uv_pinned(self) -> None:
         cmd = _build_upgrade_cmd(uv_path="/usr/bin/uv", version="1.2.0", pre=False)
@@ -83,9 +98,10 @@ class TestBuildUpgradeCmd:
         assert cmd == [
             "/usr/bin/uv",
             "tool",
-            "upgrade",
+            "install",
+            "--force",
             "--prerelease=allow",
-            "hyperi-ci",
+            "hyperi-ci@latest",
         ]
 
     def test_pip_latest(self) -> None:
@@ -121,6 +137,106 @@ class TestBuildUpgradeCmd:
             "--pre",
             "hyperi-ci",
         ]
+
+
+class TestParseInstalledVersion:
+    """Read the on-disk version out of real uv and pip output."""
+
+    # Verbatim `uv tool list` from a dev box. The entrypoint lines matter: every
+    # tool repeats its own name indented under itself, so a naive
+    # startswith("hyperi-ci") match hits "- hyperi-ci" and finds no version.
+    UV_TOOL_LIST = """ansible-core v2.21.2
+- ansible
+- ansible-config
+- ansible-playbook
+ansible-lint v26.6.0
+- ansible-lint
+headroom-ai v0.32.1
+- headroom
+hyperi-ai v3.16.96.dev1+g0e7629869
+- hyperi-ai
+hyperi-ci v2.9.5
+- hyperi-ci
+semgrep v1.171.0
+- pysemgrep
+- semgrep
+"""
+
+    PIP_SHOW = """Name: hyperi-ci
+Version: 2.9.5
+Summary: HyperI CI orchestrator
+Location: /Users/x/.venv/lib/python3.12/site-packages
+Requires: packaging, scalo, typer
+"""
+
+    def test_uv_tool_list(self) -> None:
+        assert _parse_installed_version(self.UV_TOOL_LIST, from_uv=True) == "2.9.5"
+
+    def test_uv_entrypoint_line_is_not_mistaken_for_the_tool(self) -> None:
+        """An entrypoint line repeats the name but carries no version."""
+        only_entrypoint = "somethingelse v1.0.0\n- hyperi-ci\n"
+        assert _parse_installed_version(only_entrypoint, from_uv=True) is None
+
+    def test_uv_not_installed(self) -> None:
+        assert _parse_installed_version("ruff v0.6.0\n- ruff\n", from_uv=True) is None
+
+    def test_uv_prerelease_and_local_version(self) -> None:
+        out = "hyperi-ci v3.0.0rc1+g0e76298\n- hyperi-ci\n"
+        assert _parse_installed_version(out, from_uv=True) == "3.0.0rc1+g0e76298"
+
+    def test_pip_show(self) -> None:
+        assert _parse_installed_version(self.PIP_SHOW, from_uv=False) == "2.9.5"
+
+    def test_pip_show_empty(self) -> None:
+        assert _parse_installed_version("", from_uv=False) is None
+
+    def test_uv_parser_does_not_accept_pip_output(self) -> None:
+        """Wrong from_uv flag must return None, not a wrong answer."""
+        assert _parse_installed_version(self.PIP_SHOW, from_uv=True) is None
+
+
+class TestConfirmUpgraded:
+    """Exit code 0 is not evidence; the installed version is."""
+
+    def test_true_when_version_moved(self) -> None:
+        with patch("hyperi_ci.upgrade._installed_version", return_value="2.9.5"):
+            assert _confirm_upgraded("/usr/bin/uv", "2.9.5") is True
+
+    def test_true_when_installed_is_newer_than_target(self) -> None:
+        with patch("hyperi_ci.upgrade._installed_version", return_value="2.10.0"):
+            assert _confirm_upgraded("/usr/bin/uv", "2.9.5") is True
+
+    def test_false_when_pinned_install_did_not_move(self) -> None:
+        """The reported bug: uv says "Nothing to upgrade" and exits 0."""
+        with patch("hyperi_ci.upgrade._installed_version", return_value="2.9.3"):
+            assert _confirm_upgraded("/usr/bin/uv", "2.9.4") is False
+
+    def test_false_when_version_unreadable(self) -> None:
+        with patch("hyperi_ci.upgrade._installed_version", return_value=None):
+            assert _confirm_upgraded("/usr/bin/uv", "2.9.4") is False
+
+    def test_false_on_unparseable_installed_version(self) -> None:
+        with patch(
+            "hyperi_ci.upgrade._installed_version", return_value="not-a-version"
+        ):
+            assert _confirm_upgraded("/usr/bin/uv", "2.9.4") is False
+
+
+class TestInstalledVersionAgainstRealUv:
+    """Run the real installer, no mocks -- skip when it is not there."""
+
+    def test_reads_a_version_from_real_uv(self) -> None:
+        uv_path = shutil.which("uv")
+        if uv_path is None:
+            pytest.skip("uv not on PATH")
+        version = _installed_version(uv_path)
+        if version is None:
+            pytest.skip("hyperi-ci is not installed as a uv tool on this machine")
+        # Whatever it is, it has to be a version we can compare against.
+        assert Version(version) >= Version("0")
+
+    def test_returns_none_when_installer_is_missing(self) -> None:
+        assert _installed_version("/nonexistent/bin/uv") is None
 
 
 class TestShouldAutoUpdate:


### PR DESCRIPTION
Closes #81.

Auto-update ran, did nothing, and logged that it succeeded. Two bugs feeding
each other.

`uv tool upgrade` exits 0 when it declines to act, and the only check was
`rc != 0` - so we wrote the freshness timestamp, logged a version bump, and
re-execed the same binary. Nothing re-read the installed version, so the log line
was untrue and the timestamp bought four hours of quiet before repeating it.

What makes uv decline is the other half. `upgrade --version X.Y.Z` ran
`uv tool install --force hyperi-ci==X.Y.Z`, and an exact specifier in uv's
receipt is permanent. One deliberate pin turned off every later upgrade - the
documented way to pin to a known version disabled the upgrade path.

**What changed**

- `_confirm_upgraded` re-reads the version from the installer after the command
  and compares against the target. Only then do we log success or write the
  timestamp. A stuck install warns on EVERY invocation and carries uv's own
  recovery command. No timestamp on failure, on purpose - writing one is what made
  it go quiet.
- Unpinned uv path is now `tool install --force hyperi-ci@latest`, which clears an
  existing pin as well as moving the version. That is uv's own advice in the hint.
- `--version` still pins - asking for a version is deliberate - but it now says
  what that costs and how to undo it.
- Version comes from `uv tool list` / `pip show`, not `__version__`. A process
  upgrading itself has the old one imported and cannot confirm anything.

**Verified on the real tool, not just in tests**

Pinned to 2.9.4 -> receipt gained `specifier = "==2.9.4"`. `uv tool upgrade` then
printed "Nothing to upgrade" and exited 0 with the pin hint - exactly the state
the old code called success. `_confirm_upgraded` returned False and warned.
`uv tool install --force hyperi-ci@latest` cleared the specifier and restored
2.9.5.

The parser fixture is verbatim `uv tool list` output, which is what turned up the
trap: every tool repeats its own name as an indented entrypoint line with no
version on it, so a naive name match finds nothing.

1611 unit tests pass, ruff and ruff format clean.

**Docs** - two places said to run `uv tool upgrade`. Both now point at something
that works on a pinned install.

CI was never affected, which is why this lasted: jobs use
`uvx --no-cache --refresh`, so the half everyone watches was always current.
