### PR TITLE
fix(upgrade): refresh uv's index, @latest alone can miss a release

### DIFF
--- a/docs/deployment/tiers.md
+++ b/docs/deployment/tiers.md
@@ -219,9 +219,9 @@ into an invalid state.
 
 **"contract declares schema_version=N but this hyperi-ci supports up to M"**
 Your contract was emitted by a newer producer than this hyperi-ci.
-Run `hyperi-ci upgrade` (or `uv tool install --force hyperi-ci@latest`) and
-retry. Prefer either of those over `uv tool upgrade`, which silently declines on
-an install pinned to an exact version.
+Run `hyperi-ci upgrade` (or `uv tool install --force --refresh hyperi-ci@latest`)
+and retry. Prefer either of those over `uv tool upgrade`, which silently declines
+on an install pinned to an exact version.
 
 **"Generate (Tier 3): emit-artefacts: artefact templater is not yet implemented"**
 Expected until Phase 2 ships.

--- a/docs/migration/onboarding.md
+++ b/docs/migration/onboarding.md
@@ -58,11 +58,13 @@ semantics. The biggest user-visible changes:
 2. **Bump `hyperi-ci` to >= 2.0.0** in any local install:
 
    ```bash
-   uv tool install --force hyperi-ci@latest
+   uv tool install --force --refresh hyperi-ci@latest
    ```
 
    Not `uv tool upgrade` -- it exits 0 without doing anything if the install was
-   ever pinned to an exact version.
+   ever pinned to an exact version. `--refresh` matters too: `@latest` resolves
+   against uv's cached index, so without it you can install the previous version
+   of something released minutes ago.
 
 3. **Update reusable workflow ref** in your `.github/workflows/ci.yml`:
 

--- a/src/hyperi_ci/upgrade.py
+++ b/src/hyperi_ci/upgrade.py
@@ -78,6 +78,19 @@ def _build_upgrade_cmd(
     disabled every upgrade after it. ``@latest`` both moves the version and
     clears the pin, which is uv's own advice in that message.
 
+    ``--refresh`` is on both uv paths because ``@latest`` resolves against uv's
+    CACHED index, not PyPI. Observed on the 2.9.6 release: PyPI served 2.9.6 while
+    ``tool install --force ...@latest`` installed 2.9.5 from cache, and it took
+    ``--refresh`` to see it. Auto-update reads the real latest from the PyPI JSON
+    API, so without this it asks uv for a version uv does not yet believe in --
+    which now warns rather than lying, but should not happen at all. The pinned
+    path needs it for the same reason: a version released moments ago is not in
+    the cached index either.
+
+    pip has no index-only refresh -- ``--no-cache-dir`` would also throw away the
+    wheel cache -- so the pip path is left alone. If it serves stale metadata the
+    post-check catches it.
+
     Args:
         uv_path: Path to uv binary, or None to use pip.
         version: Specific version to install, or None for latest.
@@ -88,9 +101,10 @@ def _build_upgrade_cmd(
 
     """
     if uv_path:
+        cmd = [uv_path, "tool", "install", "--force", "--refresh"]
         if version:
-            return [uv_path, "tool", "install", "--force", f"{PACKAGE}=={version}"]
-        cmd = [uv_path, "tool", "install", "--force"]
+            cmd.append(f"{PACKAGE}=={version}")
+            return cmd
         if pre:
             cmd.append("--prerelease=allow")
         cmd.append(f"{PACKAGE}@latest")
@@ -195,7 +209,7 @@ def _confirm_upgraded(uv_path: str | None, target: str) -> bool:
         logger.warning(
             f"Upgrade did not take effect -- still on {installed}, wanted {target}. "
             f"If this install is pinned, reinstall with: "
-            f"uv tool install --force {PACKAGE}@latest"
+            f"uv tool install --force --refresh {PACKAGE}@latest"
         )
     return moved
 

--- a/tests/unit/test_upgrade.py
+++ b/tests/unit/test_upgrade.py
@@ -79,6 +79,7 @@ class TestBuildUpgradeCmd:
             "tool",
             "install",
             "--force",
+            "--refresh",
             "hyperi-ci@latest",
         ]
         assert "upgrade" not in cmd
@@ -90,6 +91,7 @@ class TestBuildUpgradeCmd:
             "tool",
             "install",
             "--force",
+            "--refresh",
             "hyperi-ci==1.2.0",
         ]
 
@@ -100,9 +102,19 @@ class TestBuildUpgradeCmd:
             "tool",
             "install",
             "--force",
+            "--refresh",
             "--prerelease=allow",
             "hyperi-ci@latest",
         ]
+
+    def test_every_uv_path_refreshes_the_index(self) -> None:
+        """@latest resolves against uv's cached index, so it can miss a release."""
+        for version in (None, "1.2.0"):
+            for pre in (False, True):
+                cmd = _build_upgrade_cmd(
+                    uv_path="/usr/bin/uv", version=version, pre=pre
+                )
+                assert "--refresh" in cmd, f"missing for version={version} pre={pre}"
 
     def test_pip_latest(self) -> None:
         cmd = _build_upgrade_cmd(uv_path=None, version=None, pre=False)


### PR DESCRIPTION
fix(upgrade): refresh uv's index, @latest alone can miss a release

Follow-on from #81, found by using it. Releasing 2.9.6 and then running
`uv tool install --force hyperi-ci@latest` installed 2.9.5. PyPI had 2.9.6 and
served it over the JSON API; uv resolved `@latest` against its own CACHED index
and did not see it. `--refresh` did.

That matters more here than in a normal install, because auto-update reads the
real latest from PyPI and then hands uv a target uv does not yet believe in. The
post-upgrade check added in #81 catches it and warns instead of lying, which is
the correct floor, but the upgrade should just work.

`--refresh` goes on both uv paths, not only `@latest`. A version released moments
ago is missing from the cached index either way, so `upgrade --version X.Y.Z`
against a fresh release had the same hole.

pip is deliberately left alone: there is no index-only refresh, and
`--no-cache-dir` would throw away the wheel cache to fix a narrower problem. If
pip serves stale metadata the post-check reports it.

Verified end to end against the real installer rather than only in tests. Pinned
the install back to 2.9.5, then ran the real sequence -- `_build_upgrade_cmd` ->
`_run_upgrade_cmd` -> `_confirm_upgraded` -- and it emitted
`uv tool install --force --refresh hyperi-ci@latest`, exited 0, confirmed True,
moved 2.9.5 -> 2.9.6 and cleared the `==2.9.5` pin from the receipt with no
manual step. Which is both halves of #81 and this fix working together on a live
install.

Docs and the recovery hint in the warning now carry `--refresh` too, so the
command a user is told to run is the one that works.
