### PR TITLE
fix(upgrade): follow a live/stable channel, and stop an explicit upgrade looping

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,8 @@ No code changes, no workflow changes.
 | `hyperi-ci watch [--timeout SEC]` | Watch latest CI run (default 3600s; `--timeout 0` disables) |
 | `hyperi-ci logs [--failed]` | Show CI run logs |
 | `hyperi-ci init` | Scaffold a new project |
-| `hyperi-ci upgrade` | Upgrade to latest version |
+| `hyperi-ci upgrade` | Upgrade to the channel's release (see `autoupdate`) |
+| `hyperi-ci autoupdate [status\|channel live\|stable\|freeze\|unfreeze]` | Show/set how the CLI updates itself |
 
 `hyperi-ci release` is kept as a deprecated alias of `hyperi-ci publish`
 and will be removed in v3.0.

--- a/config/versions.yaml
+++ b/config/versions.yaml
@@ -17,7 +17,7 @@
 #   --check         current vs SSOT (dry run, default)
 #   --apply         rewrite workflows + composites to match this file
 #   --fix           --apply + non-zero exit on change (pre-commit hook)
-#   --latest        report newest release >= 7 days old per action
+#   --stable        report newest release >= 7 days old per action
 #   --auto-update   bump to those, validate LOCALLY, revert on failure. It
 #                   does not commit and does not trigger remote CI - the
 #                   ci-test-* fleet validates on the PR.
@@ -164,7 +164,7 @@ tools:
 
 # Upstream capabilities we WANT but that are not ready yet.
 #
-# `--latest` prints these on every run, so the decision resurfaces at each
+# `--stable` prints these on every run, so the decision resurfaces at each
 # dependency update instead of living in someone's memory. Each entry names the
 # gate that would let it land - something checkable, not a vibe.
 watch:

--- a/docs/README.md
+++ b/docs/README.md
@@ -74,6 +74,8 @@ Solid arrows are run-order / data flow. Dashed arrows are "calls / uses".
 - [flow.md](flow.md) - push/dispatch -> gate -> version -> build -> tag -> publish,
   one semantic-release computation driving every stage
 - [migration/ONBOARDING.md](migration/onboarding.md) - put a repo on hyperi-ci
+- [self-update.md](self-update.md) - how the CLI keeps itself current: the
+  `live` / `stable` channels, freeze, and the gates that hold an update back
 
 ### Dependencies & supply chain
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -218,6 +218,7 @@ hyperi-ci trigger | watch | logs   drive GitHub Actions from the terminal
 hyperi-ci install-toolchains | install-native-deps | install-deps   runner/CI dep install
 hyperi-ci init-contract | emit-artefacts | overlay-render | stitch | init-gitops | init-topology   deployment artefacts
 hyperi-ci upgrade                  self-upgrade the installed tool
+hyperi-ci autoupdate               channel (live|stable) / enable / freeze -- see self-update.md
 ```
 
 ### Dispatch

--- a/docs/dependencies/deps-pinning.md
+++ b/docs/dependencies/deps-pinning.md
@@ -80,7 +80,7 @@ flowchart TD
     subgraph SCRIPT["ENFORCEMENT — hyperi-ci Actions, at commit time"]
       V["config/versions.yaml<br/>version + sha"] --> H["pre-commit hook<br/>update-versions.py --fix"]
       H --> W["workflows + composites<br/>pinned @sha # version"]
-      L["--latest / --auto-update"] -->|newest release 7+ days old| V
+      L["--stable / --auto-update"] -->|newest release 7+ days old| V
     end
     subgraph REN["REMEDIATION — the forge, after the fact"]
       D["detect updates"] --> DD{"cooldown ≥7d<br/>+ timestamp"}
@@ -205,8 +205,13 @@ the full pipeline, not just top-level workflows.
 | `--check` (default) | show drift between `versions.yaml` and the pinned refs |
 | `--apply` | rewrite workflows + composites to match the SSOT |
 | `--fix` | `--apply` + non-zero exit when it changed something (pre-commit) |
-| `--latest` | report the newest release of each Action that's >=7 days old |
+| `--stable` | report the newest release of each Action that's >=7 days old |
 | `--auto-update` | bump `versions.yaml` to those, test on the `ci-test-*` projects, commit or revert |
+
+`--stable` is the SOAKED release, not the newest one - the same sense as the
+`stable` channel in [self-update.md](../self-update.md). It was spelled
+`--latest`, which read backwards: `@latest` in an installer means the edge, the
+opposite of what this resolves. `--latest` still works as a silent alias.
 
 `config/versions.yaml` is the SSOT. Two maps matter here:
 
@@ -217,7 +222,7 @@ the full pipeline, not just top-level workflows.
 reverts both to match the SSOT. To change a pin, edit `versions.yaml` and let
 `--fix` rewrite it.
 
-The "latest version that's >=7 days old, pin *that* version's SHA now" rule means
+The "newest version that's >=7 days old, pin *that* version's SHA now" rule means
 we always adopt a release only after its cooldown, and we pin the immutable SHA
 at adoption time rather than tracking a movable tag. Tools follow the same
 cooldown, but pin by tag (see the exemption above).

--- a/docs/self-update.md
+++ b/docs/self-update.md
@@ -1,0 +1,121 @@
+# Self-update: channels, freeze, and the gates
+
+hyperi-ci keeps itself current. Every invocation may check PyPI, upgrade the
+installed tool, and re-exec your command in the new binary -- so the CLI on a
+laptop matches the one baked into the runner image without anyone remembering
+to upgrade.
+
+Which release it aims at is the **channel's** decision. Same two names as
+hyperi-ai, so one mental model covers both tools:
+
+| Channel | Takes | For |
+|---|---|---|
+| `live` (default) | the newest release on PyPI, as soon as it exists | keeping up; what maintainers run |
+| `stable` | the newest release aged past the 7-day cooldown | a machine that should not move under you |
+
+```bash
+hyperi-ci autoupdate                      # status (JSON)
+hyperi-ci autoupdate channel              # print the current channel + source
+hyperi-ci autoupdate channel stable       # opt into the soak window
+hyperi-ci autoupdate disable              # stop auto-update, keep the channel
+hyperi-ci autoupdate freeze               # kill-switch: nothing updates
+hyperi-ci autoupdate unfreeze
+hyperi-ci upgrade                         # upgrade now, to the channel's release
+hyperi-ci upgrade 2.9.4                   # install exactly this (see below)
+```
+
+## It is a package, not a clone
+
+hyperi-ai's `live` follows its clone's `main` HEAD, so a commit is available the
+moment it lands. hyperi-ci is a PyPI package: `live` means the newest
+**published release**. Neither channel sees unreleased commits.
+
+`stable` ages releases by **PyPI upload time**, not tag date -- the soak window
+measured at the point a consumer can observe it, namely when the artefact became
+installable. Same 7 days as the Actions pin cooldown in
+[dependencies/DEPS-PINNING.md](dependencies/deps-pinning.md).
+
+```mermaid
+timeline
+    title A release moving through the channels
+    2.9.2 uploaded : live adopts it : stable waits
+    +7 days : stable adopts 2.9.2
+    2.9.6 uploaded : live adopts it : stable still on 2.9.2
+```
+
+While `stable` lags, the upgrade installs that exact version
+(`uv tool install --force --refresh hyperi-ci==2.9.2`), which lands in uv's
+receipt as a pin -- so a hand-run `uv tool upgrade hyperi-ci` will answer
+"Nothing to upgrade" until the lag clears. Once the soak catches up, the
+resolved target is the newest release again and the plain `@latest` form is
+used, leaving no pin behind.
+
+Switching to `stable` while already ahead of the soak window does **not** roll
+the install back. The channel holds the version still; it never downgrades. Only
+an explicit `hyperi-ci upgrade <version>` installs something older.
+
+## Where the state lives
+
+`~/.config/hyperi-ci/channel.json` -- the channel and the enable flag --
+plus `~/.config/hyperi-ci/frozen` for the kill-switch.
+
+With no channel of its own, hyperi-ci reads **hyperi-ai's**
+(`~/.config/hyperi-ai/channel.json`) as the default, because a machine that has
+configured that has already stated its intent. The read is one-way: hyperi-ci
+never writes into hyperi-ai's config, and `hyperi-ci autoupdate channel ...`
+always wins locally. `autoupdate status` reports `channel_source` as
+`hyperi-ci`, `hyperi-ai` or `default` so an inherited choice is visible.
+
+hyperi-ai's two retired names for `live`, `edge` and `nightly`, are accepted and
+normalised. Installs that predate the renames still have them in that file.
+
+Freeze spans both tools: hyperi-ci treats hyperi-ai's `frozen` flag as its own,
+because a frozen machine means nothing should move. `unfreeze` clears only
+hyperi-ci's flag and says so when the sibling's is still set.
+
+## The gates
+
+Auto-update runs only when every gate passes. `autoupdate status` reports the
+first one that does not, as `blocked_by`:
+
+| Gate | Blocks when | Notes |
+|---|---|---|
+| `recursion-guard` | `_HYPERCI_UPGRADING=1` | set on the re-exec |
+| `explicit-command` | the command is `upgrade` or `autoupdate` | managing it is not using it |
+| `frozen` | either tool's freeze flag is set | outranks every opt-in below |
+| `env-disabled` | `HYPERCI_AUTO_UPDATE=false` | what CI images set |
+| `ci` | a CI environment, without `HYPERCI_AUTO_UPDATE=true` | |
+| `disabled` | `autoupdate disable` was run | `HYPERCI_AUTO_UPDATE=true` overrides it |
+| `recently-checked` | the last check was under 4 hours ago | |
+
+`HYPERCI_AUTO_UPDATE` still works and still wins over the stored flag, being the
+more immediate statement. `autoupdate disable` is the discoverable equivalent
+for a workstation.
+
+## An explicit version is not a pin
+
+`hyperi-ci upgrade 2.9.4` installs 2.9.4 and warns, because auto-update clears
+the receipt pin it leaves and moves back to the channel target within 4 hours.
+To hold a version, hold auto-update: `hyperi-ci autoupdate freeze`.
+
+## Two failure modes worth knowing
+
+Both were live, both are now covered by tests.
+
+**A zero exit code is not evidence.** `uv tool upgrade` exits 0 when it declines
+to act, so the upgrade path confirms the version by re-reading it from the
+installer (`uv tool list` / `pip show`) rather than from `__version__` -- a
+process upgrading itself still has the old one imported. That is why
+`autoupdate status` reports `running` and `installed` separately. No timestamp
+is written on an unconfirmed upgrade: writing one is what let a stuck install go
+quiet for four hours at a time.
+
+**`@latest` resolves against uv's cached index.** PyPI served 2.9.6 while
+`tool install --force hyperi-ci@latest` installed 2.9.5, and only `--refresh`
+saw it. Both uv paths carry `--refresh`. pip has no index-only refresh, so it is
+left alone and the post-check reports stale metadata instead.
+
+`hyperi-ci upgrade` deliberately does not re-exec. It has no original command to
+carry on with, and re-exec'ing meant running `upgrade` again in the new binary --
+which, in a binary old enough to trust a zero exit code, re-execs on every
+"Nothing to upgrade" and never terminates.

--- a/scripts/update-versions.py
+++ b/scripts/update-versions.py
@@ -16,8 +16,13 @@ Usage:
     uv run scripts/update-versions.py                # default: --check
     uv run scripts/update-versions.py --check        # show drift (dry run)
     uv run scripts/update-versions.py --apply        # rewrite pipeline to SSOT
-    uv run scripts/update-versions.py --latest       # report newest release >=7d old
+    uv run scripts/update-versions.py --stable       # report newest release >=7d old
     uv run scripts/update-versions.py --auto-update  # bump SSOT, test via CI, commit/revert
+
+`--stable` reports the SOAKED release, matching the `stable` channel in
+`hyperi-ci autoupdate`. It was spelled `--latest`, which read backwards: in the
+installer `@latest` means the edge, the opposite of what this resolves.
+`--latest` still works as a silent alias.
 
 Update behaviour:
   - Actions resolve to the newest release that has aged past the 7-day
@@ -575,13 +580,17 @@ def _fix(versions: dict) -> int:
     return 1
 
 
-def _latest(versions: dict) -> int:
-    """Check for newer versions available upstream via GitHub API."""
+def _stable(versions: dict) -> int:
+    """Report the newest soaked release of each pinned Action and tool.
+
+    Soaked, not newest: a release inside the cooldown is reported as held, so
+    this answers "what may we pin to now", which is what --auto-update applies.
+    """
     actions = versions.get("actions", {})
     updates_available = 0
     lookup_failures = 0
 
-    print(f"Checking latest versions (>= {_COOLDOWN_DAYS}-day cooldown)...\n")
+    print(f"Checking stable versions (>= {_COOLDOWN_DAYS}-day cooldown)...\n")
     now = datetime.now(UTC)
 
     for short_name, current in actions.items():
@@ -795,7 +804,7 @@ def _tool_releases(spec: dict, releases: list[dict[str, Any]]) -> list[dict[str,
 def _report_watchlist(versions: dict) -> None:
     """Print `watch:` - upstream capabilities we want but that are not ready.
 
-    Surfaced on every --latest run ON PURPOSE. A "revisit this when upstream
+    Surfaced on every --stable run ON PURPOSE. A "revisit this when upstream
     stabilises" decision that lives only in a code comment is a decision nobody
     revisits; printing it at the moment someone is already updating deps is the
     cheapest place to make it resurface.
@@ -825,7 +834,7 @@ def _latest_tool_release(spec: dict, now: datetime) -> tuple[str | None, str]:
     the compatibility clamp), or `lookup-failed`.
 
     The status is NOT decoration. Collapsing all of these into a bare None made
-    --latest render an API failure as "(up to date)" - so a rate-limited `gh`
+    the report render an API failure as "(up to date)" - so a rate-limited `gh`
     reported every tool green, which is the same silent-skip shape as a pin that
     nobody enforces.
     """
@@ -1034,9 +1043,16 @@ def main() -> int:
         help="Update workflow files to match SSOT",
     )
     group.add_argument(
-        "--latest",
+        "--stable",
         action="store_true",
-        help="Check for newer versions upstream",
+        help="Report the newest release of each pin that has soaked past the cooldown",
+    )
+    # Kept working, kept out of --help: the old name for --stable.
+    group.add_argument(
+        "--latest",
+        dest="stable",
+        action="store_true",
+        help=argparse.SUPPRESS,
     )
     group.add_argument(
         "--auto-update",
@@ -1054,8 +1070,8 @@ def main() -> int:
 
     if args.auto_update:
         return _auto_update(versions)
-    if args.latest:
-        return _latest(versions)
+    if args.stable:
+        return _stable(versions)
     if args.fix:
         return _fix(versions)
     if args.apply:

--- a/src/hyperi_ci/channel.py
+++ b/src/hyperi_ci/channel.py
@@ -1,0 +1,248 @@
+# Project:   HyperI CI
+# File:      src/hyperi_ci/channel.py
+# Purpose:   Auto-update channel state (live|stable), enable flag, freeze switch
+#
+# License:   BUSL-1.1 — HYPERI PTY LIMITED
+# Copyright: (c) 2026 HYPERI PTY LIMITED
+"""Auto-update channel, enable flag and freeze switch.
+
+Same vocabulary as hyperi-ai, so one mental model covers both tools:
+
+- ``live`` (DEFAULT): the newest release, adopted as soon as it exists.
+- ``stable``: the newest release aged past the cooldown (7 days), trailing
+  live by the soak window. For a machine that should not move under you.
+
+The mechanism differs from hyperi-ai. hyperi-ai is a git clone, so its ``live``
+follows main HEAD and its ``stable`` walks git tags. hyperi-ci is a PyPI
+package with no clone, so ``live`` is the newest PUBLISHED release and
+``stable`` is resolved from PyPI upload timestamps. Neither channel tracks
+unreleased commits.
+
+Upload time rather than tag date measures the soak window at the only point a
+consumer can observe: when the artefact became installable.
+
+State lives in ``~/.config/hyperi-ci/``, not hyperi-ai's directory: hyperi-ci
+runs on machines with no hyperi-ai at all (CI runners, other people's boxes),
+so it cannot depend on a sibling tool's private config. A machine that has
+configured hyperi-ai has already stated its intent, so hyperi-ci falls back to
+reading that channel when it has none of its own. The fallback is read-only,
+and an explicit ``hyperi-ci autoupdate channel ...`` always wins locally.
+``autoupdate status`` names which source answered.
+
+Freeze is an orthogonal kill-switch, and it spans both tools: ``is_frozen()``
+is true when either flag is set, because a freeze means nothing on the machine
+should move. ``unfreeze`` clears only hyperi-ci's own flag.
+
+hyperi-ai's two retired names for ``live`` -- ``edge`` and ``nightly`` -- are
+accepted and normalised, never advertised. A hyperi-ai install lagging the
+rename still writes ``nightly`` into the file this module falls back to
+reading.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+VALID_CHANNELS: tuple[str, ...] = ("live", "stable")
+
+DEFAULT_CHANNEL = "live"
+
+# How long a release must have been on PyPI before "stable" will adopt it.
+# Deliberately the same 7 days as the Actions pin cooldown in
+# docs/dependencies/deps-pinning.md -- one soak window across the toolchain.
+COOLDOWN_DAYS = 7
+
+# hyperi-ai's pre-rename names for "live", oldest first. Accepted silently on
+# read and write, normalised before use or persistence, never advertised.
+# Listed rather than chained so a third rename does not become a third hop.
+_LEGACY_CHANNEL_ALIASES: tuple[str, ...] = ("edge", "nightly")
+
+# Module constants rather than inlined paths so tests can point them at a
+# tmp_path -- no test should read the developer's real homedir config.
+CONFIG_DIR = Path.home() / ".config" / "hyperi-ci"
+AI_CONFIG_DIR = Path.home() / ".config" / "hyperi-ai"
+
+
+def channel_path() -> Path:
+    """Return hyperi-ci's channel state file path."""
+    return CONFIG_DIR / "channel.json"
+
+
+def freeze_path() -> Path:
+    """Return hyperi-ci's freeze flag path."""
+    return CONFIG_DIR / "frozen"
+
+
+def _ai_channel_path() -> Path:
+    """Return hyperi-ai's channel state file path (read-only fallback)."""
+    return AI_CONFIG_DIR / "channel.json"
+
+
+def _ai_freeze_path() -> Path:
+    """Return hyperi-ai's freeze flag path (read-only)."""
+    return AI_CONFIG_DIR / "frozen"
+
+
+def _normalise_channel(value: object) -> str | None:
+    """Map a raw channel value to its canonical name, or None if unknown.
+
+    Args:
+        value: Raw value from a config file or the CLI; any JSON type.
+
+    Returns:
+        A name from VALID_CHANNELS, or None when unrecognised so the caller
+        can fall back to the default.
+
+    """
+    if isinstance(value, str) and value in VALID_CHANNELS:
+        return value
+    if value in _LEGACY_CHANNEL_ALIASES:
+        return "live"
+    return None
+
+
+def _read_state(path: Path) -> dict:
+    """Read a channel state file, returning {} when absent or unusable.
+
+    Args:
+        path: Channel state file to read.
+
+    Returns:
+        The parsed mapping, or an empty dict on any read/parse problem.
+
+    """
+    if not path.is_file():
+        return {}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def resolve_channel() -> tuple[str, str]:
+    """Return (channel, source) -- the channel and where it came from.
+
+    Source is ``"hyperi-ci"`` (our own config), ``"hyperi-ai"`` (inherited from
+    the sibling tool's config because we have none of our own), or
+    ``"default"``. ``autoupdate status`` prints it so an inherited channel is
+    visible rather than surprising.
+
+    The default is ``live`` rather than ``stable`` for the same reason
+    hyperi-ai chose it: a machine nobody has configured should be on the
+    current code, not silently a soak window behind it.
+
+    Returns:
+        Tuple of (channel name from VALID_CHANNELS, source label).
+
+    """
+    own = _normalise_channel(_read_state(channel_path()).get("channel"))
+    if own is not None:
+        return own, "hyperi-ci"
+    inherited = _normalise_channel(_read_state(_ai_channel_path()).get("channel"))
+    if inherited is not None:
+        return inherited, "hyperi-ai"
+    return DEFAULT_CHANNEL, "default"
+
+
+def read_channel() -> str:
+    """Return the effective channel, ignoring where it came from."""
+    return resolve_channel()[0]
+
+
+def _write_state(**updates: object) -> None:
+    """Merge updates into the channel state file, creating it if needed.
+
+    Read-modify-write rather than overwrite: channel and the enable flag live
+    in the same file, so setting one must not drop the other.
+
+    Args:
+        **updates: Keys to set in the state mapping.
+
+    """
+    path = channel_path()
+    state = _read_state(path)
+    state.update(updates)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(state, indent=2) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+
+
+def write_channel(value: str) -> None:
+    """Persist the channel, normalising a legacy alias first.
+
+    Args:
+        value: Channel name, or one of hyperi-ai's retired aliases.
+
+    Raises:
+        ValueError: If ``value`` is neither a channel nor a known alias.
+
+    """
+    normalised = _normalise_channel(value)
+    if normalised is None:
+        raise ValueError(
+            f"Invalid channel {value!r}. Must be one of: {', '.join(VALID_CHANNELS)}"
+        )
+    _write_state(channel=normalised)
+
+
+def read_enabled() -> bool:
+    """Return False only when auto-update was explicitly disabled.
+
+    Absent or malformed state means enabled -- an unconfigured machine keeps
+    tracking releases. ``HYPERCI_AUTO_UPDATE`` in the environment still wins
+    over this; see ``upgrade._should_auto_update``.
+    """
+    return _read_state(channel_path()).get("enabled") is not False
+
+
+def write_enabled(value: bool) -> None:
+    """Persist the enable flag.
+
+    Args:
+        value: True to auto-update on the configured channel, False to stop.
+
+    """
+    _write_state(enabled=bool(value))
+
+
+def is_frozen() -> bool:
+    """Return True when either tool's freeze flag is set.
+
+    A freeze is an incident kill-switch, so hyperi-ai's flag counts here too --
+    the safe reading of a frozen machine is that nothing on it should move.
+    """
+    return freeze_path().exists() or _ai_freeze_path().exists()
+
+
+def frozen_by() -> list[str]:
+    """Return which tools' freeze flags are set, for reporting."""
+    tools = []
+    if freeze_path().exists():
+        tools.append("hyperi-ci")
+    if _ai_freeze_path().exists():
+        tools.append("hyperi-ai")
+    return tools
+
+
+def freeze() -> None:
+    """Engage hyperi-ci's auto-update freeze (idempotent)."""
+    path = freeze_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.touch()
+
+
+def unfreeze() -> None:
+    """Clear hyperi-ci's own freeze flag (idempotent).
+
+    hyperi-ai's flag is left alone, so a machine frozen by the sibling tool
+    stays frozen here; ``autoupdate unfreeze`` reports that.
+    """
+    try:
+        freeze_path().unlink(missing_ok=True)
+    except OSError:
+        pass

--- a/src/hyperi_ci/cli.py
+++ b/src/hyperi_ci/cli.py
@@ -17,6 +17,8 @@ Usage:
     hyperi-ci watch [RUN_ID]            Watch a GitHub Actions run to completion
     hyperi-ci logs [RUN_ID]             Fetch and filter GitHub Actions run logs
     hyperi-ci release <tag>             Trigger publish for a version tag
+    hyperi-ci upgrade                   Upgrade to the channel's release
+    hyperi-ci autoupdate                Show/set self-update channel + freeze
     hyperi-ci check-commit              Validate commit message format
     hyperi-ci stitch <topology-dir>     Stitch a DeploymentTopology into an umbrella Helm chart
     hyperi-ci --version                 Show version
@@ -1120,11 +1122,105 @@ def upgrade(
         typer.Option("--pre", help="Include pre-releases when resolving latest"),
     ] = False,
 ) -> None:
-    """Upgrade hyperi-ci to the latest version (or a specific version)."""
+    """Upgrade hyperi-ci to its channel's release (or a specific version).
+
+    Which release "latest" means is the channel's decision: `live` (the
+    default) takes the newest release on PyPI, `stable` takes the newest one
+    that has soaked for 7 days. See `hyperi-ci autoupdate`.
+    """
     from hyperi_ci.upgrade import run_upgrade
 
     rc = run_upgrade(version=target_version, pre=pre)
     raise typer.Exit(rc)
+
+
+@app.command()
+def autoupdate(
+    action: Annotated[
+        str,
+        typer.Argument(
+            # No square brackets: rich reads them as markup and eats the text.
+            help="status (default) | enable | disable | channel live|stable "
+            "| freeze | unfreeze",
+        ),
+    ] = "status",
+    value: Annotated[
+        str | None,
+        typer.Argument(help="Target channel, for `channel`"),
+    ] = None,
+) -> None:
+    """Show or change how hyperi-ci updates itself.
+
+    Same channels as hyperi-ai, so one mental model covers both:
+
+      live    the newest release on PyPI, adopted as soon as it exists (default)
+      stable  the newest release aged past the 7-day cooldown
+
+    hyperi-ci is a PyPI package, so neither channel follows unreleased commits
+    the way hyperi-ai's clone does. `freeze` is an orthogonal kill-switch: no
+    auto-update on any channel until `unfreeze`, and hyperi-ai's freeze counts
+    here too. `disable` stops auto-update while leaving the channel set;
+    `HYPERCI_AUTO_UPDATE=false` (what the CI images set) still works and wins.
+
+    State lives in ~/.config/hyperi-ci/channel.json. With none of its own,
+    hyperi-ci inherits hyperi-ai's channel choice -- `status` names the source.
+    """
+    from hyperi_ci import channel as _channel
+    from hyperi_ci.upgrade import autoupdate_status
+
+    if action == "status":
+        typer.echo(json.dumps(autoupdate_status(), indent=2))
+        return
+
+    if action == "channel":
+        if value is None:
+            name, source = _channel.resolve_channel()
+            typer.echo(f"hyperi-ci autoupdate: channel is '{name}' (from {source})")
+            return
+        try:
+            _channel.write_channel(value)
+        except ValueError as exc:
+            typer.echo(str(exc), err=True)
+            raise typer.Exit(1) from exc
+        # Echo what was persisted -- write_channel silently normalises
+        # hyperi-ai's retired "edge" and "nightly" aliases to "live".
+        typer.echo(f"hyperi-ci autoupdate: channel set to '{_channel.read_channel()}'")
+        return
+
+    if action in ("enable", "disable"):
+        _channel.write_enabled(action == "enable")
+        typer.echo(f"hyperi-ci autoupdate: {action}d")
+        if os.environ.get("HYPERCI_AUTO_UPDATE", "").lower() in ("true", "false"):
+            typer.echo(
+                "note: HYPERCI_AUTO_UPDATE is set in this environment and "
+                "overrides the stored flag"
+            )
+        return
+
+    if action == "freeze":
+        _channel.freeze()
+        typer.echo(
+            "hyperi-ci autoupdate: FROZEN (no updates on any channel). "
+            "Clear with `hyperi-ci autoupdate unfreeze`."
+        )
+        return
+
+    if action == "unfreeze":
+        _channel.unfreeze()
+        typer.echo("hyperi-ci autoupdate: unfrozen")
+        if _channel.is_frozen():
+            typer.echo(
+                "note: still frozen by hyperi-ai -- clear that with "
+                "`hyperi-ai autoupdate unfreeze`"
+            )
+        return
+
+    typer.echo(f"Unknown action: {action}", err=True)
+    typer.echo(
+        "Valid: status, enable, disable, channel [live|stable], freeze, unfreeze",
+        err=True,
+    )
+    raise typer.Exit(1)
 
 
 @app.command(name="init-contract")

--- a/src/hyperi_ci/upgrade.py
+++ b/src/hyperi_ci/upgrade.py
@@ -4,7 +4,14 @@
 #
 # License:   BUSL-1.1 — HYPERI PTY LIMITED
 # Copyright: (c) 2026 HYPERI PTY LIMITED
-"""Self-upgrade functionality for hyperi-ci CLI."""
+"""Self-upgrade functionality for hyperi-ci CLI.
+
+Which release an upgrade aims at is the channel's decision (see
+:mod:`hyperi_ci.channel`): ``live`` takes the newest release on PyPI, ``stable``
+takes the newest one that has soaked past the cooldown. Everything below the
+target resolution -- building the installer command, confirming the version
+actually moved, re-exec -- is the same on both channels.
+"""
 
 from __future__ import annotations
 
@@ -15,12 +22,14 @@ import subprocess
 import sys
 import time
 import urllib.request
+from datetime import UTC, datetime
 from pathlib import Path
+from typing import NamedTuple
 
 from packaging.version import InvalidVersion, Version
 from scalo.logger import logger
 
-from hyperi_ci import __version__
+from hyperi_ci import __version__, channel
 from hyperi_ci.common import is_ci
 
 PACKAGE = "hyperi-ci"
@@ -61,6 +70,188 @@ def _parse_latest_version(
     latest_stable = str(max(stable)) if stable else None
     latest_pre = str(max(all_versions)) if all_versions else None
     return latest_stable, latest_pre
+
+
+def _release_upload_time(files: list[dict]) -> float | None:
+    """Return when a release first became installable, as a unix timestamp.
+
+    The earliest file wins: a release with an sdist uploaded before its wheels
+    was installable from that moment, which is the point the soak starts.
+
+    PyPI's older ``upload_time`` field carries no offset, and a naive datetime
+    would be read as local time -- hours of error either way in the soak. Both
+    fields are UTC, so a missing offset is filled in as UTC.
+
+    Args:
+        files: PyPI file entries for one release.
+
+    Returns:
+        Unix timestamp, or None when no entry carries a parseable time.
+
+    """
+    stamps: list[float] = []
+    for entry in files:
+        raw = entry.get("upload_time_iso_8601") or entry.get("upload_time")
+        if not isinstance(raw, str):
+            continue
+        try:
+            parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+            stamps.append(
+                (parsed if parsed.tzinfo else parsed.replace(tzinfo=UTC)).timestamp()
+            )
+        except ValueError:
+            continue
+    return min(stamps) if stamps else None
+
+
+def _stable_releases_newest_first(
+    releases: dict[str, list],
+) -> list[tuple[Version, float | None]]:
+    """Return (version, upload time) for real releases, newest version first.
+
+    Pre-releases and dev-releases are dropped: a channel that waits out a soak
+    window has no business adopting one.
+
+    Args:
+        releases: PyPI releases mapping {version_string: [file_dicts]}.
+
+    Returns:
+        List of (version, upload timestamp or None), newest version first.
+
+    """
+    found: list[tuple[Version, float | None]] = []
+    for ver_str, files in releases.items():
+        if not files:
+            continue
+        try:
+            version = Version(ver_str)
+        except InvalidVersion:
+            continue
+        if version.is_prerelease or version.is_devrelease:
+            continue
+        found.append((version, _release_upload_time(files)))
+    return sorted(found, key=lambda pair: pair[0], reverse=True)
+
+
+def _soaked_version(
+    releases: dict[str, list],
+    *,
+    cooldown_days: int = channel.COOLDOWN_DAYS,
+    now: float | None = None,
+) -> str | None:
+    """Return the newest release aged past the cooldown, or None if none has.
+
+    Newest first; the first release old enough wins. A release whose upload
+    time cannot be read is skipped rather than assumed old -- fail closed, so
+    an unreadable timestamp holds the channel back instead of advancing it.
+
+    Args:
+        releases: PyPI releases mapping.
+        cooldown_days: Days a release must have been installable.
+        now: Unix timestamp to age against (tests); defaults to the clock.
+
+    Returns:
+        Version string, or None when nothing qualifies.
+
+    """
+    moment = time.time() if now is None else now
+    for version, uploaded in _stable_releases_newest_first(releases):
+        if uploaded is None:
+            continue
+        if (moment - uploaded) / 86400.0 >= cooldown_days:
+            return str(version)
+    return None
+
+
+def _newest_with_age(
+    releases: dict[str, list],
+    *,
+    now: float | None = None,
+) -> tuple[str, float] | None:
+    """Return (newest release, its age in days), for reporting only.
+
+    This is what ``stable`` is waiting on when :func:`_soaked_version` comes
+    back short of it, so the upgrade can say which release it is holding out on
+    and for how much longer. The adoption decision stays with
+    :func:`_soaked_version`.
+
+    Args:
+        releases: PyPI releases mapping.
+        now: Unix timestamp to age against (tests); defaults to the clock.
+
+    Returns:
+        Tuple of (version string, age in days), or None when none is datable.
+
+    """
+    moment = time.time() if now is None else now
+    for version, uploaded in _stable_releases_newest_first(releases):
+        if uploaded is not None:
+            return str(version), (moment - uploaded) / 86400.0
+    return None
+
+
+class UpgradeTarget(NamedTuple):
+    """What a channel resolved to, and how to install it.
+
+    Attributes:
+        version: Release to install, or None when the channel has nothing to
+            offer (no release has soaked yet, or PyPI could not be read).
+        pin: Install the exact version rather than ``@latest``. True only while
+            ``stable`` lags the newest release; an exact specifier lands in
+            uv's receipt as a pin, so it is not used when ``@latest`` resolves
+            to the same version anyway.
+        note: What the channel is holding out on, for logging. None when
+            nothing is being held back.
+
+    """
+
+    version: str | None
+    pin: bool
+    note: str | None
+
+
+def _resolve_target(
+    releases: dict[str, list],
+    *,
+    channel_name: str,
+    pre: bool = False,
+    now: float | None = None,
+) -> UpgradeTarget:
+    """Resolve which release the channel wants installed.
+
+    ``pre`` resolves as ``live`` whatever the channel: a pre-release has not
+    soaked by definition, so asking for one is asking to leave the soak window.
+
+    Args:
+        releases: PyPI releases mapping.
+        channel_name: "live" or "stable".
+        pre: Include pre-releases when resolving.
+        now: Unix timestamp to age against (tests); defaults to the clock.
+
+    Returns:
+        The resolved :class:`UpgradeTarget`.
+
+    """
+    latest_stable, latest_pre = _parse_latest_version(releases)
+    if pre:
+        return UpgradeTarget(version=latest_pre, pin=False, note=None)
+    if channel_name != "stable":
+        return UpgradeTarget(version=latest_stable, pin=False, note=None)
+
+    soaked = _soaked_version(releases, now=now)
+    newest = _newest_with_age(releases, now=now)
+    note = None
+    if newest is not None and newest[0] != soaked:
+        remaining = channel.COOLDOWN_DAYS - newest[1]
+        note = (
+            f"stable is holding at {soaked or 'nothing yet'}: "
+            f"{newest[0]} is {newest[1]:.1f} days old, "
+            f"adopted in {max(remaining, 0):.1f} days"
+        )
+    # Pin only while stable lags, so a receipt pin exists exactly as long as
+    # the soak lag does.
+    pin = soaked is not None and soaked != latest_stable
+    return UpgradeTarget(version=soaked, pin=pin, note=note)
 
 
 def _build_upgrade_cmd(
@@ -214,6 +405,31 @@ def _confirm_upgraded(uv_path: str | None, target: str) -> bool:
     return moved
 
 
+def _effective_current(uv_path: str | None) -> Version:
+    """Return the newer of the running version and the one on disk.
+
+    They diverge when the command came from a source checkout, and for one
+    invocation after an upgrade. Taking the newer of the two is what stops a
+    channel whose target is older than the installed tool -- ``stable`` during
+    its soak lag -- from downgrading it.
+
+    Args:
+        uv_path: Path to uv binary, or None to ask pip.
+
+    Returns:
+        The higher of the two versions; the running one when disk is unreadable.
+
+    """
+    running = Version(__version__)
+    installed = _installed_version(uv_path)
+    if installed is None:
+        return running
+    try:
+        return max(running, Version(installed))
+    except InvalidVersion:
+        return running
+
+
 def _timestamp_age() -> float:
     """Return age of timestamp file in seconds, or infinity if missing."""
     try:
@@ -234,28 +450,72 @@ def _should_auto_update() -> bool:
 
     Returns False if any gate blocks the update.
     """
-    # Recursion guard
-    if os.environ.get("_HYPERCI_UPGRADING") == "1":
-        return False
+    return _blocking_gate() is None
 
-    # Skip when the user is running "upgrade" explicitly
-    if len(sys.argv) >= 2 and sys.argv[1] == "upgrade":
-        return False
 
-    # Explicit env var override (takes precedence over CI detection)
+def _blocking_gate(*, ignore_invocation: bool = False) -> str | None:
+    """Name the first gate that blocks auto-update, or None when none does.
+
+    One list of gates, in precedence order, so ``autoupdate status`` reports
+    the same decision the callback makes rather than a second copy of it.
+
+    Args:
+        ignore_invocation: Skip the recursion guard and the
+            explicit-command gate, which say nothing about the machine's
+            configuration and are noise when reporting status.
+
+    Returns:
+        Gate name, or None when auto-update may proceed.
+
+    """
+    if not ignore_invocation:
+        if os.environ.get("_HYPERCI_UPGRADING") == "1":
+            return "recursion-guard"
+        # The user is running "upgrade" or managing auto-update explicitly
+        if len(sys.argv) >= 2 and sys.argv[1] in ("upgrade", "autoupdate"):
+            return "explicit-command"
+
+    # The freeze kill-switch outranks every opt-in below it, including
+    # HYPERCI_AUTO_UPDATE=true.
+    if channel.is_frozen():
+        return "frozen"
+
+    # Explicit env var override (takes precedence over CI detection and over
+    # the persisted enable flag, being the more immediate statement)
     auto_update_env = os.environ.get("HYPERCI_AUTO_UPDATE", "").lower()
     if auto_update_env == "false":
-        return False
+        return "env-disabled"
     if auto_update_env == "true":
         pass  # Explicit opt-in, skip CI check
     elif is_ci():
-        return False
+        return "ci"
+    elif not channel.read_enabled():
+        return "disabled"
 
-    # Timestamp check
     if _timestamp_age() < CHECK_INTERVAL:
-        return False
+        return "recently-checked"
 
-    return True
+    return None
+
+
+def _fetch_releases() -> dict[str, list]:
+    """Fetch the PyPI releases mapping, or {} on any error.
+
+    One request serves both the version list and the upload timestamps the
+    stable channel ages against.
+
+    Returns:
+        PyPI releases mapping {version_string: [file_dicts]}.
+
+    """
+    try:
+        req = urllib.request.Request(PYPI_URL, headers={"Accept": "application/json"})
+        with urllib.request.urlopen(req, timeout=PYPI_TIMEOUT) as resp:  # nosec B310  # nosemgrep: dynamic-urllib-use-detected — hardcoded PyPI HTTPS URL
+            data = json.loads(resp.read())
+    except Exception:
+        return {}
+    releases = data.get("releases", {})
+    return releases if isinstance(releases, dict) else {}
 
 
 def _fetch_pypi_versions() -> tuple[str | None, str | None]:
@@ -265,13 +525,7 @@ def _fetch_pypi_versions() -> tuple[str | None, str | None]:
         Tuple of (latest_stable, latest_prerelease). Both None on error.
 
     """
-    try:
-        req = urllib.request.Request(PYPI_URL, headers={"Accept": "application/json"})
-        with urllib.request.urlopen(req, timeout=PYPI_TIMEOUT) as resp:  # nosec B310  # nosemgrep: dynamic-urllib-use-detected — hardcoded PyPI HTTPS URL
-            data = json.loads(resp.read())
-        return _parse_latest_version(data.get("releases", {}))
-    except Exception:
-        return None, None
+    return _parse_latest_version(_fetch_releases())
 
 
 def _run_upgrade_cmd(cmd: list[str]) -> int:
@@ -311,6 +565,60 @@ def _re_exec() -> None:
         raise SystemExit(0)
 
 
+def _refuse_when_frozen() -> bool:
+    """Report whether hyperi-ci's own freeze flag blocks an explicit upgrade.
+
+    hyperi-ai's flag is not a veto on a command the operator typed here; it is
+    reported and the upgrade proceeds. hyperi-ci's own flag is a refusal,
+    because a kill-switch a routine command walks straight through is not one.
+
+    Returns:
+        True when the caller must abort.
+
+    """
+    holders = channel.frozen_by()
+    if "hyperi-ci" in holders:
+        logger.error(
+            "Auto-update is frozen. Clear it first: hyperi-ci autoupdate unfreeze"
+        )
+        return True
+    if "hyperi-ai" in holders:
+        logger.warning(
+            "hyperi-ai auto-update is frozen on this machine; upgrading hyperi-ci "
+            "anyway because it was asked for explicitly"
+        )
+    return False
+
+
+def _explicit_target(pre: bool) -> UpgradeTarget | None:
+    """Resolve the target for an unpinned ``hyperi-ci upgrade``.
+
+    Args:
+        pre: Include pre-releases when resolving.
+
+    Returns:
+        The resolved target, or None when it could not be resolved (already
+        logged).
+
+    """
+    releases = _fetch_releases()
+    if not releases:
+        logger.error("Could not determine latest version from PyPI")
+        return None
+    channel_name, source = channel.resolve_channel()
+    logger.info(f"Channel: {channel_name} (from {source})")
+    target = _resolve_target(releases, channel_name=channel_name, pre=pre)
+    if target.note:
+        logger.info(target.note)
+    if target.version is None:
+        logger.error(
+            f"No release has soaked past the {channel.COOLDOWN_DAYS}-day cooldown "
+            f"yet. Switch channel to move now: hyperi-ci autoupdate channel live"
+        )
+        return None
+    return target
+
+
 def run_upgrade(
     version: str | None = None,
     pre: bool = False,
@@ -318,27 +626,32 @@ def run_upgrade(
     """Run an explicit upgrade.
 
     Args:
-        version: Specific version to install, or None for latest.
+        version: Specific version to install, or None to follow the channel.
         pre: Include pre-releases.
 
     Returns:
         Exit code (0 = success).
 
     """
-    # Resolve target version
-    if version:
-        target = version
-    else:
-        stable, prerelease = _fetch_pypi_versions()
-        target = prerelease if pre else stable
-        if target is None:
-            logger.error("Could not determine latest version from PyPI")
-            return 1
+    if _refuse_when_frozen():
+        return 1
 
-    current = Version(__version__)
+    if version:
+        resolved = UpgradeTarget(version=version, pin=True, note=None)
+    else:
+        maybe = _explicit_target(pre)
+        if maybe is None:
+            return 1
+        resolved = maybe
+
+    target = resolved.version
+    if target is None:
+        return 1
+    uv_path = shutil.which("uv")
+    current = _effective_current(uv_path)
     try:
         target_ver = Version(target)
-    except Exception:
+    except InvalidVersion:
         logger.error(f"Invalid version: {target}")
         return 1
 
@@ -346,11 +659,15 @@ def run_upgrade(
         logger.info(f"Already up to date ({current})")
         return 0
 
-    # Build and run upgrade command
-    uv_path = shutil.which("uv")
+    if version is None and current > target_ver:
+        # A channel resolves to a target, it does not roll the install back:
+        # only an explicit version argument may install something older.
+        logger.info(f"Already ahead of the channel target ({current} > {target_ver})")
+        return 0
+
     cmd = _build_upgrade_cmd(
         uv_path=uv_path,
-        version=target if version else None,
+        version=target if resolved.pin else None,
         pre=pre,
     )
     logger.info(f"Upgrading: {' '.join(cmd)}")
@@ -363,18 +680,22 @@ def run_upgrade(
     if not _confirm_upgraded(uv_path, target):
         return 1
 
-    if version and uv_path:
-        # An explicit --version is a deliberate act, so honour it -- but say out
-        # loud what it costs, because uv records it as an exact pin and every
-        # later auto-update will decline without explaining why.
+    if version:
+        # An explicit version is a deliberate act, so honour it -- but say what
+        # it does not do, because auto-update clears the receipt pin it leaves
+        # and moves back to the channel target on its next check.
         logger.warning(
-            f"Pinned to {target}. Auto-updates will not move off it. "
-            f"To go back to tracking latest: hyperi-ci upgrade"
+            f"Installed {target} explicitly. Auto-update will move back to the "
+            f"channel target within {CHECK_INTERVAL // 3600}h -- hold here with: "
+            f"hyperi-ci autoupdate freeze"
         )
 
     logger.info(f"{PACKAGE} upgraded: {current} -> {target}")
-    _re_exec()
-    return 0  # unreachable after execvpe, keeps type checker happy
+    # No re-exec here. `hyperi-ci upgrade` has no original command to carry on
+    # with, so re-exec'ing means running `upgrade` again in the new binary --
+    # and a new binary old enough to trust a zero exit code (before #82) then
+    # re-execs on every "Nothing to upgrade", which never terminates.
+    return 0
 
 
 def maybe_auto_update() -> None:
@@ -387,34 +708,93 @@ def maybe_auto_update() -> None:
         if not _should_auto_update():
             return
 
-        stable, _ = _fetch_pypi_versions()
-        if stable is None:
+        releases = _fetch_releases()
+        if not releases:
             return
 
-        current = Version(__version__)
-        latest = Version(stable)
-        if current >= latest:
+        channel_name, _ = channel.resolve_channel()
+        resolved = _resolve_target(releases, channel_name=channel_name)
+        if resolved.version is None:
+            # Nothing has soaked yet on stable. The check ran and answered, so
+            # record it rather than re-asking PyPI on every invocation.
+            _write_timestamp()
+            return
+
+        uv_path = shutil.which("uv")
+        current = _effective_current(uv_path)
+        if current >= Version(resolved.version):
+            # Never downgrades: switching to stable while ahead of the soak
+            # window holds the version still, it does not roll back.
             _write_timestamp()
             return
 
         # Upgrade needed
-        uv_path = shutil.which("uv")
-        cmd = _build_upgrade_cmd(uv_path=uv_path, version=None, pre=False)
+        cmd = _build_upgrade_cmd(
+            uv_path=uv_path,
+            version=resolved.version if resolved.pin else None,
+            pre=False,
+        )
 
         rc = _run_upgrade_cmd(cmd)
         if rc != 0:
             logger.warning(f"Auto-update failed (exit {rc})")
             return
 
-        if not _confirm_upgraded(uv_path, stable):
+        if not _confirm_upgraded(uv_path, resolved.version):
             # Deliberately no timestamp. Writing one here is what let a stuck
             # install go quiet for four hours at a time, so leave the check due
             # and let the next invocation try again and warn again.
             return
 
         _write_timestamp()
-        logger.info(f"{PACKAGE} upgraded: {current} -> {stable}")
+        logger.info(f"{PACKAGE} upgraded: {current} -> {resolved.version}")
         _re_exec()
 
     except Exception as exc:
         logger.warning(f"Auto-update check failed: {exc}")
+
+
+def autoupdate_status() -> dict:
+    """Report what auto-update would do, for ``hyperi-ci autoupdate status``.
+
+    Makes one PyPI request so the report names the actual target, not just the
+    channel. Network keys come back None when PyPI cannot be read.
+
+    ``running`` and ``installed`` differ when the command came from a source
+    checkout, and again for one invocation after an upgrade -- the running
+    process still has the old ``__version__`` imported. The decisions use
+    ``running``.
+
+    Returns:
+        Mapping of the channel state, the resolved target, and the gates.
+
+    """
+    channel_name, source = channel.resolve_channel()
+    env = os.environ.get("HYPERCI_AUTO_UPDATE", "")
+    age = _timestamp_age()
+    releases = _fetch_releases()
+    latest, _ = _parse_latest_version(releases)
+    resolved = (
+        _resolve_target(releases, channel_name=channel_name)
+        if releases
+        else UpgradeTarget(version=None, pin=False, note=None)
+    )
+    return {
+        "running": __version__,
+        "installed": _installed_version(shutil.which("uv")),
+        "channel": channel_name,
+        "channel_source": source,
+        "cooldown_days": channel.COOLDOWN_DAYS,
+        "enabled": channel.read_enabled(),
+        "frozen": channel.is_frozen(),
+        "frozen_by": channel.frozen_by(),
+        "env_override": env or None,
+        "in_ci": is_ci(),
+        "blocked_by": _blocking_gate(ignore_invocation=True),
+        "hours_since_check": None if age == float("inf") else round(age / 3600, 2),
+        "check_interval_hours": CHECK_INTERVAL // 3600,
+        "latest_on_pypi": latest,
+        "channel_target": resolved.version,
+        "holding": resolved.note,
+        "state_file": str(channel.channel_path()),
+    }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,34 @@
+# Project:   HyperI CI
+# File:      tests/conftest.py
+# Purpose:   Shared fixtures -- keep the suite off the developer's real config
+#
+# License:   BUSL-1.1 — HYPERI PTY LIMITED
+# Copyright: (c) 2026 HYPERI PTY LIMITED
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hyperi_ci import channel
+
+
+@pytest.fixture(autouse=True)
+def isolated_channel_state(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point auto-update channel/freeze state at tmp_path for every test.
+
+    Without this a developer who has run `hyperi-ci autoupdate freeze` (or has
+    hyperi-ai frozen) sees auto-update tests fail on their machine and pass in
+    CI. The state is two files in the homedir, so the only safe default is to
+    redirect both tools' directories.
+
+    Returns:
+        The redirected hyperi-ci config directory.
+
+    """
+    ci_dir = tmp_path / "config-hyperi-ci"
+    ai_dir = tmp_path / "config-hyperi-ai"
+    monkeypatch.setattr(channel, "CONFIG_DIR", ci_dir)
+    monkeypatch.setattr(channel, "AI_CONFIG_DIR", ai_dir)
+    return ci_dir

--- a/tests/unit/test_channel.py
+++ b/tests/unit/test_channel.py
@@ -1,0 +1,150 @@
+# Project:   HyperI CI
+# File:      tests/unit/test_channel.py
+# Purpose:   Tests for auto-update channel, enable flag and freeze state
+#
+# License:   BUSL-1.1 — HYPERI PTY LIMITED
+# Copyright: (c) 2026 HYPERI PTY LIMITED
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from hyperi_ci import channel
+
+
+def _write(path: Path, payload: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+class TestReadChannel:
+    """Resolve the channel from our config, hyperi-ai's, or the default."""
+
+    def test_defaults_to_live(self) -> None:
+        assert channel.resolve_channel() == ("live", "default")
+
+    def test_reads_own_config(self) -> None:
+        _write(channel.channel_path(), {"channel": "stable"})
+        assert channel.resolve_channel() == ("stable", "hyperi-ci")
+
+    def test_inherits_hyperi_ai_channel_when_we_have_none(self) -> None:
+        _write(channel.AI_CONFIG_DIR / "channel.json", {"channel": "stable"})
+        assert channel.resolve_channel() == ("stable", "hyperi-ai")
+
+    def test_own_config_beats_hyperi_ai(self) -> None:
+        _write(channel.channel_path(), {"channel": "live"})
+        _write(channel.AI_CONFIG_DIR / "channel.json", {"channel": "stable"})
+        assert channel.resolve_channel() == ("live", "hyperi-ci")
+
+    def test_stale_hyperi_ai_nightly_normalises_to_live(self) -> None:
+        """An older hyperi-ai still writes the retired name into that file."""
+        _write(channel.AI_CONFIG_DIR / "channel.json", {"channel": "nightly"})
+        assert channel.resolve_channel() == ("live", "hyperi-ai")
+
+    def test_edge_alias_normalises_to_live(self) -> None:
+        _write(channel.channel_path(), {"channel": "edge"})
+        assert channel.read_channel() == "live"
+
+    def test_unknown_channel_falls_back_to_default(self) -> None:
+        _write(channel.channel_path(), {"channel": "banana"})
+        assert channel.resolve_channel() == ("live", "default")
+
+    def test_malformed_json_falls_back_to_default(self) -> None:
+        path = channel.channel_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("{not json", encoding="utf-8")
+        assert channel.read_channel() == "live"
+
+    def test_non_mapping_json_falls_back_to_default(self) -> None:
+        _write(channel.channel_path(), ["live"])
+        assert channel.read_channel() == "live"
+
+
+class TestWriteChannel:
+    """Persist the canonical name, never the alias."""
+
+    def test_round_trip(self) -> None:
+        channel.write_channel("stable")
+        assert channel.read_channel() == "stable"
+
+    def test_persists_canonical_name_for_an_alias(self) -> None:
+        channel.write_channel("nightly")
+        stored = json.loads(channel.channel_path().read_text(encoding="utf-8"))
+        assert stored["channel"] == "live"
+
+    def test_rejects_unknown_channel(self) -> None:
+        with pytest.raises(ValueError, match="Invalid channel"):
+            channel.write_channel("banana")
+
+    def test_creates_the_config_dir(self) -> None:
+        assert not channel.channel_path().exists()
+        channel.write_channel("live")
+        assert channel.channel_path().is_file()
+
+
+class TestEnabledFlag:
+    """The enable flag shares one file with the channel."""
+
+    def test_enabled_by_default(self) -> None:
+        assert channel.read_enabled() is True
+
+    def test_disable_then_enable(self) -> None:
+        channel.write_enabled(False)
+        assert channel.read_enabled() is False
+        channel.write_enabled(True)
+        assert channel.read_enabled() is True
+
+    def test_setting_the_channel_keeps_the_enable_flag(self) -> None:
+        channel.write_enabled(False)
+        channel.write_channel("stable")
+        assert channel.read_enabled() is False
+        assert channel.read_channel() == "stable"
+
+    def test_setting_the_enable_flag_keeps_the_channel(self) -> None:
+        channel.write_channel("stable")
+        channel.write_enabled(False)
+        assert channel.read_channel() == "stable"
+
+
+class TestFreeze:
+    """Freeze spans both tools; unfreeze only clears our own."""
+
+    def test_not_frozen_by_default(self) -> None:
+        assert channel.is_frozen() is False
+        assert channel.frozen_by() == []
+
+    def test_freeze_and_unfreeze(self) -> None:
+        channel.freeze()
+        assert channel.is_frozen() is True
+        assert channel.frozen_by() == ["hyperi-ci"]
+        channel.unfreeze()
+        assert channel.is_frozen() is False
+
+    def test_hyperi_ai_freeze_counts(self) -> None:
+        ai_flag = channel.AI_CONFIG_DIR / "frozen"
+        ai_flag.parent.mkdir(parents=True, exist_ok=True)
+        ai_flag.touch()
+        assert channel.is_frozen() is True
+        assert channel.frozen_by() == ["hyperi-ai"]
+
+    def test_unfreeze_leaves_hyperi_ai_frozen(self) -> None:
+        ai_flag = channel.AI_CONFIG_DIR / "frozen"
+        ai_flag.parent.mkdir(parents=True, exist_ok=True)
+        ai_flag.touch()
+        channel.freeze()
+        channel.unfreeze()
+        assert channel.freeze_path().exists() is False
+        assert channel.is_frozen() is True
+
+    def test_freeze_is_idempotent(self) -> None:
+        channel.freeze()
+        channel.freeze()
+        assert channel.frozen_by() == ["hyperi-ci"]
+
+    def test_unfreeze_is_idempotent(self) -> None:
+        channel.unfreeze()
+        channel.unfreeze()
+        assert channel.is_frozen() is False

--- a/tests/unit/test_update_versions.py
+++ b/tests/unit/test_update_versions.py
@@ -507,7 +507,7 @@ class TestToolReleases:
 class TestLatestToolRelease:
     """(tag, status) - the status is load-bearing, not decoration.
 
-    Collapsing these into a bare None made --latest render an API failure as
+    Collapsing these into a bare None made --stable render an API failure as
     "(up to date)": a rate-limited `gh` reported every tool green.
     """
 
@@ -768,3 +768,26 @@ class TestRewriteReturnCodes:
         pin.write_text(_DRIFTED_BODY, encoding="utf-8")
         assert update_versions._fix(_pin_versions()) == 1
         assert pin.read_text(encoding="utf-8") == _PIN_BODY
+
+
+class TestStableFlagAndItsAlias:
+    """`--stable` is the name; `--latest` keeps working, unadvertised."""
+
+    def _dispatch(self, monkeypatch, argv: list[str], verb: str) -> list[str]:
+        called: list[str] = []
+        monkeypatch.setattr(update_versions, "_load_versions", lambda: {})
+        monkeypatch.setattr(
+            update_versions, verb, lambda _versions: called.append(verb) or 0
+        )
+        monkeypatch.setattr("sys.argv", ["update-versions.py", *argv])
+        assert update_versions.main() == 0
+        return called
+
+    def test_stable_dispatches_the_report(self, monkeypatch) -> None:
+        assert self._dispatch(monkeypatch, ["--stable"], "_stable") == ["_stable"]
+
+    def test_latest_still_dispatches_the_same_report(self, monkeypatch) -> None:
+        assert self._dispatch(monkeypatch, ["--latest"], "_stable") == ["_stable"]
+
+    def test_no_flag_still_defaults_to_check(self, monkeypatch) -> None:
+        assert self._dispatch(monkeypatch, [], "_check") == ["_check"]

--- a/tests/unit/test_upgrade.py
+++ b/tests/unit/test_upgrade.py
@@ -18,17 +18,68 @@ from unittest.mock import patch
 import pytest
 from packaging.version import Version
 
+from hyperi_ci import channel
 from hyperi_ci.upgrade import (
     CHECK_INTERVAL,
+    _blocking_gate,
     _build_upgrade_cmd,
     _confirm_upgraded,
+    _effective_current,
     _fetch_pypi_versions,
     _installed_version,
+    _newest_with_age,
     _parse_installed_version,
     _parse_latest_version,
+    _release_upload_time,
+    _resolve_target,
     _run_upgrade_cmd,
     _should_auto_update,
+    _soaked_version,
+    autoupdate_status,
+    maybe_auto_update,
+    run_upgrade,
 )
+
+# Ages are measured from the module-load clock, so the resolvers called with an
+# explicit `now` and the paths that read the real clock agree on them.
+NOW = time.time()
+DAY = 86400.0
+
+
+def _iso(offset_days: float) -> str:
+    """Return an ISO upload time that many days before NOW."""
+    from datetime import UTC, datetime
+
+    return (
+        datetime.fromtimestamp(NOW - offset_days * DAY, tz=UTC)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def _releases(**ages: float) -> dict[str, list]:
+    """Build a PyPI releases mapping from {version: age in days}."""
+    return {ver: [{"upload_time_iso_8601": _iso(age)}] for ver, age in ages.items()}
+
+
+@pytest.fixture(autouse=True)
+def _no_installer_lookup(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Stop the suite reading whichever hyperi-ci this machine has installed.
+
+    `_effective_current` asks the installer for the on-disk version, so without
+    this a developer with 2.9.6 installed sees different results from CI. Tests
+    that exercise the lookup patch it themselves or call it directly.
+    """
+    monkeypatch.setattr("hyperi_ci.upgrade._installed_version", lambda _uv: None)
+
+
+# 2.9.6 is inside the 7-day window, so stable holds at 2.9.4 while live takes it.
+SOAK_SAMPLE = {
+    "2.9.4": [{"upload_time_iso_8601": _iso(30)}],
+    "2.9.5": [{"upload_time_iso_8601": _iso(2)}],
+    "2.9.6": [{"upload_time_iso_8601": _iso(1)}],
+    "3.0.0rc1": [{"upload_time_iso_8601": _iso(40)}],
+}
 
 
 class TestParseLatestVersion:
@@ -372,6 +423,506 @@ class TestFetchPypiVersions:
             stable, pre = _fetch_pypi_versions()
         assert stable is None
         assert pre is None
+
+
+class TestReleaseUploadTime:
+    """When a release first became installable."""
+
+    def test_earliest_file_wins(self) -> None:
+        files = [
+            {"upload_time_iso_8601": _iso(1)},
+            {"upload_time_iso_8601": _iso(5)},
+        ]
+        assert _release_upload_time(files) == pytest.approx(NOW - 5 * DAY)
+
+    def test_falls_back_to_upload_time(self) -> None:
+        """The non-8601 key is the older PyPI field name for the same value."""
+        files = [{"upload_time": "2026-07-29T22:38:10"}]
+        assert _release_upload_time(files) is not None
+
+    def test_an_offsetless_time_is_read_as_utc_not_local(self) -> None:
+        """Reading PyPI's naive `upload_time` as local time skews the soak."""
+        naive = _release_upload_time([{"upload_time": "2026-07-29T22:38:10"}])
+        aware = _release_upload_time([{"upload_time_iso_8601": "2026-07-29T22:38:10Z"}])
+        assert naive == aware
+
+    def test_unparseable_time_is_ignored(self) -> None:
+        files = [{"upload_time_iso_8601": "not-a-time"}]
+        assert _release_upload_time(files) is None
+
+    def test_no_time_at_all(self) -> None:
+        assert _release_upload_time([{"filename": "x"}]) is None
+
+    def test_empty(self) -> None:
+        assert _release_upload_time([]) is None
+
+
+class TestSoakedVersion:
+    """Which release the stable channel is allowed to adopt."""
+
+    def test_picks_the_newest_release_past_the_cooldown(self) -> None:
+        assert _soaked_version(SOAK_SAMPLE, now=NOW) == "2.9.4"
+
+    def test_adopts_a_release_once_it_ages_in(self) -> None:
+        # 6.5 rather than 6 days on: it puts 2.9.6 at 7.5 days, clear of the
+        # boundary. At exactly 7.0 the microsecond rounding of the ISO
+        # round-trip decides the answer, which is what the two tests below pin
+        # deliberately instead of by accident.
+        later = NOW + 6.5 * DAY
+        assert _soaked_version(SOAK_SAMPLE, now=later) == "2.9.6"
+
+    def test_exactly_at_the_cooldown_qualifies(self) -> None:
+        """The window is >= cooldown, so the boundary itself is in."""
+        files = [{"upload_time_iso_8601": _iso(0)}]
+        uploaded = _release_upload_time(files)
+        assert uploaded is not None
+        releases = {"1.0.0": files}
+        assert _soaked_version(releases, now=uploaded + 7 * DAY) == "1.0.0"
+
+    def test_a_moment_short_of_the_cooldown_does_not(self) -> None:
+        files = [{"upload_time_iso_8601": _iso(0)}]
+        uploaded = _release_upload_time(files)
+        assert uploaded is not None
+        releases = {"1.0.0": files}
+        assert _soaked_version(releases, now=uploaded + 7 * DAY - 1) is None
+
+    def test_none_when_nothing_has_soaked(self) -> None:
+        assert _soaked_version(_releases(**{"1.0.0": 1.0}), now=NOW) is None
+
+    def test_ignores_prereleases(self) -> None:
+        """3.0.0rc1 is the oldest here, and still must not be adopted."""
+        assert _soaked_version(SOAK_SAMPLE, now=NOW) != "3.0.0rc1"
+
+    def test_undatable_release_is_skipped_not_assumed_old(self) -> None:
+        releases = {
+            "2.0.0": [{"filename": "x"}],
+            "1.0.0": [{"upload_time_iso_8601": _iso(30)}],
+        }
+        assert _soaked_version(releases, now=NOW) == "1.0.0"
+
+    def test_empty_releases(self) -> None:
+        assert _soaked_version({}, now=NOW) is None
+
+    def test_release_with_no_files_is_skipped(self) -> None:
+        releases = {"2.0.0": [], "1.0.0": [{"upload_time_iso_8601": _iso(30)}]}
+        assert _soaked_version(releases, now=NOW) == "1.0.0"
+
+
+class TestNewestWithAge:
+    """What stable is waiting on, for reporting."""
+
+    def test_reports_the_newest_release_and_its_age(self) -> None:
+        result = _newest_with_age(SOAK_SAMPLE, now=NOW)
+        assert result is not None
+        version, age = result
+        assert version == "2.9.6"
+        assert age == pytest.approx(1.0)
+
+    def test_none_when_nothing_is_datable(self) -> None:
+        assert _newest_with_age({"1.0.0": [{"filename": "x"}]}, now=NOW) is None
+
+
+class TestResolveTarget:
+    """The channel decides which release an upgrade aims at."""
+
+    def test_live_takes_the_newest_release(self) -> None:
+        target = _resolve_target(SOAK_SAMPLE, channel_name="live", now=NOW)
+        assert target.version == "2.9.6"
+        assert target.pin is False
+        assert target.note is None
+
+    def test_stable_holds_at_the_soaked_release(self) -> None:
+        target = _resolve_target(SOAK_SAMPLE, channel_name="stable", now=NOW)
+        assert target.version == "2.9.4"
+
+    def test_stable_pins_while_it_lags(self) -> None:
+        """@latest would install the edge, so the lagging target must be exact."""
+        target = _resolve_target(SOAK_SAMPLE, channel_name="stable", now=NOW)
+        assert target.pin is True
+
+    def test_stable_does_not_pin_once_caught_up(self) -> None:
+        """No receipt pin in the steady state, so `uv tool upgrade` still works."""
+        caught_up = _releases(**{"2.9.4": 30.0, "2.9.6": 10.0})
+        target = _resolve_target(caught_up, channel_name="stable", now=NOW)
+        assert target.version == "2.9.6"
+        assert target.pin is False
+
+    def test_stable_says_what_it_is_holding_out_on(self) -> None:
+        target = _resolve_target(SOAK_SAMPLE, channel_name="stable", now=NOW)
+        assert target.note is not None
+        assert "2.9.6" in target.note
+        assert "2.9.4" in target.note
+
+    def test_stable_with_nothing_soaked_yet(self) -> None:
+        target = _resolve_target(
+            _releases(**{"1.0.0": 1.0}), channel_name="stable", now=NOW
+        )
+        assert target.version is None
+        assert target.note is not None
+
+    def test_pre_resolves_as_live_whatever_the_channel(self) -> None:
+        target = _resolve_target(SOAK_SAMPLE, channel_name="stable", pre=True, now=NOW)
+        assert target.version == "3.0.0rc1"
+        assert target.pin is False
+
+    def test_unknown_channel_name_behaves_as_live(self) -> None:
+        target = _resolve_target(SOAK_SAMPLE, channel_name="banana", now=NOW)
+        assert target.version == "2.9.6"
+
+
+class TestBlockingGate:
+    """Which gate holds auto-update back, in precedence order."""
+
+    def _clean_env(self) -> dict[str, str]:
+        drop = (
+            "CI",
+            "GITHUB_ACTIONS",
+            "GITLAB_CI",
+            "JENKINS_URL",
+            "BUILDKITE",
+            "_HYPERCI_UPGRADING",
+            "HYPERCI_AUTO_UPDATE",
+        )
+        return {k: v for k, v in os.environ.items() if k not in drop}
+
+    def test_no_gate_when_nothing_blocks(self, tmp_path: Path) -> None:
+        with patch("hyperi_ci.upgrade.TIMESTAMP_FILE", tmp_path / "none"):
+            with patch.dict(os.environ, self._clean_env(), clear=True):
+                assert _blocking_gate() is None
+
+    def test_freeze_beats_an_explicit_env_opt_in(self, tmp_path: Path) -> None:
+        """A kill-switch that an opt-in overrides is not a kill-switch."""
+        channel.freeze()
+        env = self._clean_env()
+        env["HYPERCI_AUTO_UPDATE"] = "true"
+        with patch("hyperi_ci.upgrade.TIMESTAMP_FILE", tmp_path / "none"):
+            with patch.dict(os.environ, env, clear=True):
+                assert _blocking_gate() == "frozen"
+
+    def test_hyperi_ai_freeze_blocks_too(self, tmp_path: Path) -> None:
+        ai_flag = channel.AI_CONFIG_DIR / "frozen"
+        ai_flag.parent.mkdir(parents=True, exist_ok=True)
+        ai_flag.touch()
+        with patch("hyperi_ci.upgrade.TIMESTAMP_FILE", tmp_path / "none"):
+            with patch.dict(os.environ, self._clean_env(), clear=True):
+                assert _blocking_gate() == "frozen"
+
+    def test_disabled_flag_blocks(self, tmp_path: Path) -> None:
+        channel.write_enabled(False)
+        with patch("hyperi_ci.upgrade.TIMESTAMP_FILE", tmp_path / "none"):
+            with patch.dict(os.environ, self._clean_env(), clear=True):
+                assert _blocking_gate() == "disabled"
+
+    def test_env_opt_in_beats_the_disabled_flag(self, tmp_path: Path) -> None:
+        channel.write_enabled(False)
+        env = self._clean_env()
+        env["HYPERCI_AUTO_UPDATE"] = "true"
+        with patch("hyperi_ci.upgrade.TIMESTAMP_FILE", tmp_path / "none"):
+            with patch.dict(os.environ, env, clear=True):
+                assert _blocking_gate() is None
+
+    def test_env_disabled_is_named(self) -> None:
+        with patch.dict(os.environ, {"HYPERCI_AUTO_UPDATE": "false"}):
+            assert _blocking_gate() == "env-disabled"
+
+    def test_ci_is_named(self) -> None:
+        env = self._clean_env()
+        env["CI"] = "true"
+        with patch.dict(os.environ, env, clear=True):
+            assert _blocking_gate() == "ci"
+
+    def test_explicit_command_is_named(self) -> None:
+        with patch("sys.argv", ["hyperi-ci", "autoupdate", "status"]):
+            assert _blocking_gate() == "explicit-command"
+
+    def test_ignore_invocation_skips_the_command_gates(self, tmp_path: Path) -> None:
+        """Status must report the machine's config, not that status was typed."""
+        with patch("hyperi_ci.upgrade.TIMESTAMP_FILE", tmp_path / "none"):
+            with patch.dict(os.environ, self._clean_env(), clear=True):
+                with patch("sys.argv", ["hyperi-ci", "autoupdate"]):
+                    assert _blocking_gate(ignore_invocation=True) is None
+
+    def test_managing_autoupdate_does_not_trigger_an_update(self) -> None:
+        with patch("sys.argv", ["hyperi-ci", "autoupdate", "channel", "stable"]):
+            assert _should_auto_update() is False
+
+
+class TestAutoupdateStatus:
+    """What `hyperi-ci autoupdate status` reports."""
+
+    def test_reports_channel_source_and_target(self, tmp_path: Path) -> None:
+        channel.write_channel("stable")
+        with patch("hyperi_ci.upgrade._fetch_releases", return_value=SOAK_SAMPLE):
+            with patch("hyperi_ci.upgrade.TIMESTAMP_FILE", tmp_path / "none"):
+                status = autoupdate_status()
+        assert status["channel_target"] == "2.9.4"
+        assert status["holding"] is not None
+        assert status["channel"] == "stable"
+        assert status["channel_source"] == "hyperi-ci"
+        assert status["latest_on_pypi"] == "2.9.6"
+        assert status["enabled"] is True
+        assert status["frozen"] is False
+        assert status["hours_since_check"] is None
+
+    def test_survives_pypi_being_unreachable(self, tmp_path: Path) -> None:
+        with patch("hyperi_ci.upgrade._fetch_releases", return_value={}):
+            with patch("hyperi_ci.upgrade.TIMESTAMP_FILE", tmp_path / "none"):
+                status = autoupdate_status()
+        assert status["latest_on_pypi"] is None
+        assert status["channel_target"] is None
+
+    def test_separates_the_running_version_from_the_installed_one(
+        self, tmp_path: Path
+    ) -> None:
+        """Conflating the two is what #82 was: a self-upgrade cannot see itself."""
+        with patch("hyperi_ci.upgrade._fetch_releases", return_value={}):
+            with patch("hyperi_ci.upgrade.TIMESTAMP_FILE", tmp_path / "none"):
+                with patch("hyperi_ci.upgrade.__version__", "2.9.3"):
+                    with patch(
+                        "hyperi_ci.upgrade._installed_version", return_value="2.9.6"
+                    ):
+                        status = autoupdate_status()
+        assert status["running"] == "2.9.3"
+        assert status["installed"] == "2.9.6"
+
+    def test_names_the_freeze_holder(self, tmp_path: Path) -> None:
+        channel.freeze()
+        with patch("hyperi_ci.upgrade._fetch_releases", return_value={}):
+            with patch("hyperi_ci.upgrade.TIMESTAMP_FILE", tmp_path / "none"):
+                status = autoupdate_status()
+        assert status["frozen"] is True
+        assert status["frozen_by"] == ["hyperi-ci"]
+        assert status["blocked_by"] == "frozen"
+
+
+class TestEffectiveCurrent:
+    """The running version and the one on disk are not the same number."""
+
+    def test_uses_the_running_version_when_disk_is_unreadable(self) -> None:
+        with patch("hyperi_ci.upgrade.__version__", "2.9.3"):
+            assert _effective_current("/uv") == Version("2.9.3")
+
+    def test_takes_the_installed_version_when_it_is_newer(self) -> None:
+        """A source checkout runs an old version against a current install."""
+        with patch("hyperi_ci.upgrade.__version__", "2.3.10"):
+            with patch("hyperi_ci.upgrade._installed_version", return_value="2.9.6"):
+                assert _effective_current("/uv") == Version("2.9.6")
+
+    def test_keeps_the_running_version_when_it_is_newer(self) -> None:
+        with patch("hyperi_ci.upgrade.__version__", "2.9.6"):
+            with patch("hyperi_ci.upgrade._installed_version", return_value="2.9.2"):
+                assert _effective_current("/uv") == Version("2.9.6")
+
+    def test_unparseable_installed_version_is_ignored(self) -> None:
+        with patch("hyperi_ci.upgrade.__version__", "2.9.3"):
+            with patch(
+                "hyperi_ci.upgrade._installed_version", return_value="not-a-version"
+            ):
+                assert _effective_current("/uv") == Version("2.9.3")
+
+    def test_stable_does_not_downgrade_a_newer_install(self, tmp_path: Path) -> None:
+        """Running from a checkout must not drag the install back to the soak."""
+        channel.write_channel("stable")
+        with patch("hyperi_ci.upgrade._fetch_releases", return_value=SOAK_SAMPLE):
+            with patch("hyperi_ci.upgrade.__version__", "2.3.10"):
+                with patch(
+                    "hyperi_ci.upgrade._installed_version", return_value="2.9.6"
+                ):
+                    with patch("hyperi_ci.upgrade._run_upgrade_cmd") as mock_run:
+                        assert run_upgrade() == 0
+        mock_run.assert_not_called()
+
+
+class TestRunUpgradeFreeze:
+    """An explicit upgrade against the freeze switch."""
+
+    def test_refused_when_hyperi_ci_is_frozen(self) -> None:
+        channel.freeze()
+        with patch("hyperi_ci.upgrade._run_upgrade_cmd") as mock_run:
+            assert run_upgrade() == 1
+        mock_run.assert_not_called()
+
+    def test_proceeds_when_only_hyperi_ai_is_frozen(self) -> None:
+        """A sibling tool's flag is not a veto on a command typed here."""
+        ai_flag = channel.AI_CONFIG_DIR / "frozen"
+        ai_flag.parent.mkdir(parents=True, exist_ok=True)
+        ai_flag.touch()
+        with patch("hyperi_ci.upgrade._fetch_releases", return_value=SOAK_SAMPLE):
+            with patch(
+                "hyperi_ci.upgrade._run_upgrade_cmd", return_value=0
+            ) as mock_run:
+                with patch("hyperi_ci.upgrade._confirm_upgraded", return_value=True):
+                    with patch("hyperi_ci.upgrade._re_exec"):
+                        run_upgrade()
+        mock_run.assert_called_once()
+
+
+class TestRunUpgradeChannel:
+    """The channel decides what an unpinned `hyperi-ci upgrade` installs."""
+
+    def _upgrade_cmd(self) -> list[str]:
+        with patch("hyperi_ci.upgrade._fetch_releases", return_value=SOAK_SAMPLE):
+            with patch(
+                "hyperi_ci.upgrade._run_upgrade_cmd", return_value=0
+            ) as mock_run:
+                with patch("hyperi_ci.upgrade._confirm_upgraded", return_value=True):
+                    with patch("hyperi_ci.upgrade.shutil.which", return_value="/uv"):
+                        run_upgrade()
+        return list(mock_run.call_args[0][0])
+
+    def test_does_not_re_exec(self) -> None:
+        """Re-exec'ing `upgrade` runs it again, which loops on an older binary."""
+        with patch("hyperi_ci.upgrade._fetch_releases", return_value=SOAK_SAMPLE):
+            with patch("hyperi_ci.upgrade._run_upgrade_cmd", return_value=0):
+                with patch("hyperi_ci.upgrade._confirm_upgraded", return_value=True):
+                    with patch("hyperi_ci.upgrade._re_exec") as mock_exec:
+                        assert run_upgrade() == 0
+        mock_exec.assert_not_called()
+
+    def test_live_installs_at_latest(self) -> None:
+        channel.write_channel("live")
+        assert "hyperi-ci@latest" in self._upgrade_cmd()
+
+    def test_stable_installs_the_soaked_version_exactly(self) -> None:
+        channel.write_channel("stable")
+        assert "hyperi-ci==2.9.4" in self._upgrade_cmd()
+
+    def test_does_not_downgrade_to_the_soaked_version(self) -> None:
+        """Switching to stable while ahead holds the install, it does not roll back."""
+        channel.write_channel("stable")
+        with patch("hyperi_ci.upgrade._fetch_releases", return_value=SOAK_SAMPLE):
+            with patch("hyperi_ci.upgrade.__version__", "2.9.6"):
+                with patch("hyperi_ci.upgrade._run_upgrade_cmd") as mock_run:
+                    assert run_upgrade() == 0
+        mock_run.assert_not_called()
+
+    def test_an_explicit_version_may_go_backwards(self) -> None:
+        """A named version is a deliberate act, downgrade included."""
+        with patch("hyperi_ci.upgrade.__version__", "2.9.6"):
+            with patch(
+                "hyperi_ci.upgrade._run_upgrade_cmd", return_value=0
+            ) as mock_run:
+                with patch("hyperi_ci.upgrade._confirm_upgraded", return_value=True):
+                    with patch("hyperi_ci.upgrade._re_exec"):
+                        with patch(
+                            "hyperi_ci.upgrade.shutil.which", return_value="/uv"
+                        ):
+                            run_upgrade(version="2.9.4")
+        assert "hyperi-ci==2.9.4" in list(mock_run.call_args[0][0])
+
+    def test_fails_when_nothing_has_soaked(self) -> None:
+        channel.write_channel("stable")
+        fresh = _releases(**{"1.0.0": 1.0})
+        with patch("hyperi_ci.upgrade._fetch_releases", return_value=fresh):
+            with patch("hyperi_ci.upgrade._run_upgrade_cmd") as mock_run:
+                assert run_upgrade() == 1
+        mock_run.assert_not_called()
+
+    def test_fails_when_pypi_is_unreadable(self) -> None:
+        with patch("hyperi_ci.upgrade._fetch_releases", return_value={}):
+            with patch("hyperi_ci.upgrade._run_upgrade_cmd") as mock_run:
+                assert run_upgrade() == 1
+        mock_run.assert_not_called()
+
+
+class TestMaybeAutoUpdate:
+    """The unattended path honours the same channel decision."""
+
+    def _run(self, tmp_path: Path) -> list[str] | None:
+        drop = (
+            "CI",
+            "GITHUB_ACTIONS",
+            "GITLAB_CI",
+            "JENKINS_URL",
+            "BUILDKITE",
+            "_HYPERCI_UPGRADING",
+            "HYPERCI_AUTO_UPDATE",
+        )
+        env = {k: v for k, v in os.environ.items() if k not in drop}
+        with patch("hyperi_ci.upgrade.TIMESTAMP_FILE", tmp_path / "ts"):
+            with patch("hyperi_ci.upgrade.CACHE_DIR", tmp_path):
+                with patch.dict(os.environ, env, clear=True):
+                    with patch("sys.argv", ["hyperi-ci", "config"]):
+                        with patch(
+                            "hyperi_ci.upgrade._fetch_releases",
+                            return_value=SOAK_SAMPLE,
+                        ):
+                            with patch("hyperi_ci.upgrade.__version__", "2.9.3"):
+                                with patch(
+                                    "hyperi_ci.upgrade._run_upgrade_cmd",
+                                    return_value=0,
+                                ) as mock_run:
+                                    with patch(
+                                        "hyperi_ci.upgrade._confirm_upgraded",
+                                        return_value=True,
+                                    ):
+                                        with patch("hyperi_ci.upgrade._re_exec"):
+                                            maybe_auto_update()
+        if not mock_run.called:
+            return None
+        return list(mock_run.call_args[0][0])
+
+    def test_live_auto_update_tracks_latest(self, tmp_path: Path) -> None:
+        channel.write_channel("live")
+        cmd = self._run(tmp_path)
+        assert cmd is not None
+        assert "hyperi-ci@latest" in cmd
+
+    def test_stable_auto_update_installs_the_soaked_version(
+        self, tmp_path: Path
+    ) -> None:
+        channel.write_channel("stable")
+        cmd = self._run(tmp_path)
+        assert cmd is not None
+        assert "hyperi-ci==2.9.4" in cmd
+
+    def test_frozen_does_nothing(self, tmp_path: Path) -> None:
+        channel.freeze()
+        assert self._run(tmp_path) is None
+
+    def test_disabled_does_nothing(self, tmp_path: Path) -> None:
+        channel.write_enabled(False)
+        assert self._run(tmp_path) is None
+
+    def test_stable_with_nothing_soaked_records_the_check(self, tmp_path: Path) -> None:
+        """A check that ran and answered "wait" must not re-ask PyPI every call."""
+        channel.write_channel("stable")
+        drop = ("CI", "GITHUB_ACTIONS", "_HYPERCI_UPGRADING", "HYPERCI_AUTO_UPDATE")
+        env = {k: v for k, v in os.environ.items() if k not in drop}
+        fresh = _releases(**{"9.9.9": 1.0})
+        with patch("hyperi_ci.upgrade.TIMESTAMP_FILE", tmp_path / "ts"):
+            with patch("hyperi_ci.upgrade.CACHE_DIR", tmp_path):
+                with patch.dict(os.environ, env, clear=True):
+                    with patch("sys.argv", ["hyperi-ci", "config"]):
+                        with patch(
+                            "hyperi_ci.upgrade._fetch_releases", return_value=fresh
+                        ):
+                            with patch(
+                                "hyperi_ci.upgrade._run_upgrade_cmd"
+                            ) as mock_run:
+                                maybe_auto_update()
+        mock_run.assert_not_called()
+        assert (tmp_path / "ts").is_file()
+
+    def test_never_downgrades(self, tmp_path: Path) -> None:
+        """Switching to stable while ahead of the soak window holds, not rolls back."""
+        channel.write_channel("stable")
+        drop = ("CI", "GITHUB_ACTIONS", "_HYPERCI_UPGRADING", "HYPERCI_AUTO_UPDATE")
+        env = {k: v for k, v in os.environ.items() if k not in drop}
+        with patch("hyperi_ci.upgrade.TIMESTAMP_FILE", tmp_path / "ts"):
+            with patch("hyperi_ci.upgrade.CACHE_DIR", tmp_path):
+                with patch.dict(os.environ, env, clear=True):
+                    with patch("sys.argv", ["hyperi-ci", "config"]):
+                        with patch(
+                            "hyperi_ci.upgrade._fetch_releases",
+                            return_value=SOAK_SAMPLE,
+                        ):
+                            with patch("hyperi_ci.upgrade.__version__", "2.9.6"):
+                                with patch(
+                                    "hyperi_ci.upgrade._run_upgrade_cmd"
+                                ) as mock_run:
+                                    maybe_auto_update()
+        mock_run.assert_not_called()
 
 
 class TestRunUpgradeCmd:


### PR DESCRIPTION
Self-update took whatever PyPI called latest, so a machine that should not move
under you had no way to say so short of turning auto-update off entirely. It now
follows a channel, using the same two words hyperi-ai uses so one mental model
covers both tools:

- `live` (default) - the newest published release, adopted as soon as it exists
- `stable` - the newest release aged past the 7-day soak

```
hyperi-ci autoupdate                   # status (JSON)
hyperi-ci autoupdate channel stable    # opt into the soak window
hyperi-ci autoupdate disable|freeze    # stop it; freeze is the kill-switch
hyperi-ci upgrade                      # upgrade now, to the channel's release
```

The mechanism differs from hyperi-ai's and the docstrings say so: hyperi-ai is a
clone whose `live` follows HEAD and whose `stable` walks tags, while hyperi-ci is
a package, so neither channel here sees unreleased commits. `stable` ages
releases by PyPI upload time - the soak measured where a consumer can actually
observe it, at the point the artefact became installable.

State is ours (`~/.config/hyperi-ci/channel.json`) because hyperi-ci runs on
machines with no hyperi-ai at all - CI runners, other people's boxes. With no
channel of its own it inherits hyperi-ai's rather than assuming, and `status`
names the source so an inherited choice is visible. Freeze is OR-ed across both
tools, since a frozen machine means nothing should move; `unfreeze` clears only
our own flag and says when the sibling's is still set.

While `stable` lags, the install pins the exact version - `@latest` would fetch
the edge - and once the soak catches up it goes back to `@latest`, so the uv
receipt carries a pin for exactly as long as the lag does.

`HYPERCI_AUTO_UPDATE` keeps working and keeps winning over the stored flag;
`autoupdate disable` is the discoverable equivalent for a workstation. The gates
now live in one list, so `status` reports the same decision the callback makes
instead of a second copy of it.

Second commit renames the deps helper's `--latest` to `--stable`. It reported the
newest release that had aged PAST the cooldown, which is the opposite of what the
word means everywhere else here. `--latest` still works, hidden from `--help`.

## Four bugs, all found by running it

Two of them only a live run would have caught, which is the whole point:

- The channel path would have **downgraded** an explicit `upgrade`: a machine on
  2.9.6 switching to `stable` would have installed 2.9.2.
- The re-exec in `run_upgrade` was an **infinite loop**. It installed the soaked
  2.9.2 and re-exec'd into it, and 2.9.2 predates #82, so it trusted uv's zero
  exit on "Nothing to upgrade", logged a success that had not happened, and
  re-exec'd again - dozens of processes in four minutes. An explicit upgrade has
  no original command to carry on with, so it no longer re-execs; auto-update
  keeps its re-exec, which is what re-exec is for.
- PyPI's older `upload_time` field carries no offset, and a naive datetime is
  read as **local time** - ten hours of soak skew on an AEST box.
- A **source checkout** (running 2.3.10, installed 2.9.6) would have dragged the
  installed tool back to the soaked release. The comparison now uses the newer of
  the running and installed versions.

## Verification

- 1802 tests pass (was 1791); `hyperi-ci check` green.
- Live against real PyPI: `stable` resolved 2.9.2 while holding 2.9.6 at 0.1 days
  old. Cross-checked against PyPI's own JSON - 2.9.2 uploaded 8 days ago (soaked),
  2.9.3 6.1 days ago (correctly held).
- Real installer in an isolated `UV_TOOL_DIR`: emitted
  `uv tool install --force --refresh hyperi-ci==2.9.2`, uv installed it, exited
  once, no loop.
- Every verb exercised end to end, including the alias normalisation and the
  refusal while frozen.
- `tests/conftest.py` (new) redirects both tools' config dirs at `tmp_path` and
  stubs the installer lookup, so the suite stops depending on what the developer
  has installed or frozen.

Docs: `docs/self-update.md`, indexed from `docs/README.md`.
