### PR TITLE
fix(release): tag with the CI bot App token, not GITHUB_TOKEN

### DIFF
--- a/.github/workflows/_release-tail.yml
+++ b/.github/workflows/_release-tail.yml
@@ -222,6 +222,12 @@ jobs:
       issues: write
       pull-requests: write
       packages: write
+    env:
+      # Mapped to env because the `secrets` context is not readable from a
+      # step-level `if`, and the release identity turns on whether this repo
+      # can see the App key at all (the org secret is `selected`, and this is
+      # a reusable workflow -- `secrets: inherit` resolves in the CALLER).
+      RELEASE_APP_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -231,6 +237,36 @@ jobs:
           ref: ${{ inputs.tag || github.ref }}
           fetch-depth: 0
           persist-credentials: false
+
+      - name: Mint the release bot token
+        # Tag, commit and release-commit all PUSH. As `github-actions` those
+        # pushes cannot be excepted from a branch ruleset -- rulesets only
+        # accept org-installed apps as bypass actors and GitHub refuses the
+        # first-party integration -- so a repo wanting required status checks
+        # cannot have them (issue #86). A GITHUB_TOKEN push also triggers no
+        # workflows, leaving the release commit invisible to anything that
+        # should react to it.
+        id: bot
+        if: env.RELEASE_APP_KEY != ''
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.GH_APP_CLIENT_ID }}
+          private-key: ${{ env.RELEASE_APP_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-contents: write
+          permission-issues: write
+          permission-pull-requests: write
+
+      - name: Report the release identity
+        # A silent fall back to github-actions is what makes a missing ruleset
+        # bypass look like a working release, so say which identity is in use.
+        run: |
+          if [ "${{ steps.bot.outcome }}" = "success" ]; then
+            echo "Tagging and pushing as hypersec-ci-bot."
+          else
+            echo "::warning::GH_APP_PRIVATE_KEY is not visible to this repo — tagging as github-actions. Required status checks cannot be bypassed, and the release push will trigger no workflows. Add this repo to the GH_APP_PRIVATE_KEY org secret's selected list to fix both."
+          fi
 
       - name: Setup semantic-release (shared toolchain — single source of truth)
         # Runs the version oracle on a push, and on a from-head `auto`
@@ -278,8 +314,8 @@ jobs:
         # oracle. Once the first tag exists this branch never fires again.
         if: ${{ github.event_name == 'push' || (inputs.from-head == 'true' && inputs.bump == 'auto') }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.bot.outputs.token || secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.bot.outputs.token || secrets.GITHUB_TOKEN }}
         run: |
           if [ -z "$(git tag --list 'v[0-9]*')" ]; then
             echo "Tag-less repo — first release: tagging HEAD v${{ inputs.next-version }} from the plan's prediction"
@@ -336,7 +372,7 @@ jobs:
         id: forcedtag
         if: ${{ inputs.from-head == 'true' && inputs.bump != 'auto' && inputs.bump != '' }}
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.bot.outputs.token || secrets.GITHUB_TOKEN }}
         run: ${{ env.HYPERCI_INSTALL }} tag-head --bump ${{ inputs.bump }}
 
       - name: Publish
@@ -371,7 +407,9 @@ jobs:
         if: steps.publish.outcome == 'success'
         continue-on-error: true
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Also a push to the default branch, so it needs the bypass actor
+          # for the same reason the tag does.
+          GH_TOKEN: ${{ steps.bot.outputs.token || secrets.GITHUB_TOKEN }}
         run: >-
           ${{ env.HYPERCI_INSTALL }} release-commit
           "${{ steps.forcedtag.outputs.version || inputs.next-version }}"

--- a/tests/unit/test_workflow_consistency.py
+++ b/tests/unit/test_workflow_consistency.py
@@ -621,3 +621,59 @@ def test_release_tail_uses_shared_workflow(workflow_name: str) -> None:
         f"Every language workflow must delegate container + tag-and-publish "
         f"to the shared release-tail workflow."
     )
+
+
+# Steps in _release-tail.yml that PUSH to the default branch or create a tag.
+# Named by the `name:` field so a reordering does not silently drop one.
+_PUSHING_STEPS = (
+    "Tag (semantic-release)",
+    "Tag HEAD (forced bump / explicit version)",
+    "Commit rendered release artefacts",
+)
+
+_BOT_TOKEN = "${{ steps.bot.outputs.token || secrets.GITHUB_TOKEN }}"
+
+
+def _tag_and_publish_steps() -> list[dict]:
+    wf = _load_workflow("_release-tail.yml")
+    return wf["jobs"]["tag-and-publish"]["steps"]
+
+
+def test_release_tail_mints_a_bot_token() -> None:
+    """The App token must be minted from the Client ID, not the App ID.
+
+    `app-id` is deprecated in actions/create-github-app-token, and the Client
+    ID is a different value rather than a rename, so a swap back would fail at
+    token-mint time instead of at review.
+    """
+    steps = _tag_and_publish_steps()
+    mint = [s for s in steps if s.get("id") == "bot"]
+    assert mint, (
+        "_release-tail.tag-and-publish: no `bot` step minting an App token. "
+        "Pushes made as github-actions cannot be excepted from a branch "
+        "ruleset and trigger no workflows (issue #86)."
+    )
+    with_ = mint[0].get("with", {})
+    assert "client-id" in with_, "the bot token must be minted from client-id"
+    assert "app-id" not in with_, "app-id is deprecated — use client-id"
+
+
+@pytest.mark.parametrize("step_name", _PUSHING_STEPS)
+def test_pushing_steps_use_the_bot_token(step_name: str) -> None:
+    """Every step that writes to the repo must prefer the App token.
+
+    A bare `secrets.GITHUB_TOKEN` here is the regression that reintroduces
+    issue #86: the push lands as github-actions, which no ruleset can grant a
+    bypass to, so the repo cannot carry required status checks.
+    """
+    steps = _tag_and_publish_steps()
+    matching = [s for s in steps if s.get("name") == step_name]
+    assert matching, f"_release-tail: step {step_name!r} has gone or been renamed"
+    env = matching[0].get("env", {})
+    tokens = {k: v for k, v in env.items() if k in ("GH_TOKEN", "GITHUB_TOKEN")}
+    assert tokens, f"{step_name}: expected a GH_TOKEN/GITHUB_TOKEN in env"
+    for key, value in tokens.items():
+        assert value == _BOT_TOKEN, (
+            f"{step_name}: {key} is {value!r}, expected the bot token with a "
+            f"GITHUB_TOKEN fallback ({_BOT_TOKEN!r})."
+        )


### PR DESCRIPTION
Closes #86.

Rulesets only accept org-installed apps as bypass actors and GitHub refuses the
first-party `github-actions` integration outright, so a repo whose release tail
tags as `github-actions` cannot carry required status checks on its default
branch. That is why culvert shipped with `deletion` + `non_fast_forward` only
and no quality gate. A `GITHUB_TOKEN` push also triggers no workflows, so the
release commit is invisible to anything that should react to it.

**Three steps push, not the two in the issue.** `Tag (semantic-release)`,
`Tag HEAD (forced bump)` and `Commit rendered release artefacts` all write.
release-commit reaches the default branch through the Git Data API, so required
checks would block it for the same reason they block the tag - worth knowing
before someone turns protection on and wonders why #85's commit-back died.

## How it behaves

- Minted from `GH_APP_CLIENT_ID`, not the deprecated `app-id`. Confirmed from
  the action's own `action.yml` at v3, which carries
  `deprecationMessage: "Use 'client-id' instead."` on `app-id`.
- The mint is gated on the App key being visible to the CALLING repo, because
  `GH_APP_PRIVATE_KEY` is a `selected` org secret and this is a reusable
  workflow under `secrets: inherit`. A repo not on that list keeps working on
  `GITHUB_TOKEN` and emits a `::warning::` naming the fix. Silence there would
  make a missing ruleset bypass look like a working release.
- The key is mapped to job `env` because the `secrets` context is not readable
  from a step-level `if`.

Publish, GHCR login and release-notify stay on `GITHUB_TOKEN` - none of them
push to a protected branch. That answers the "worth checking" in the issue: the
Publish step creates a GitHub Release, which no ruleset gates.

## Verified, and not

Verified: the full unit suite (1875), and new tests pinning all three write
paths plus the client-id mint. Those were checked by reverting one path and
watching that case fail, rather than assuming a passing test means anything.

NOT verified: an end-to-end release actually tagged as the bot. That needs a
repo on the secret's selected list AND a ruleset with required checks, and no
such release was run here. The mint mechanism itself is proven - the same action
version and the same client-id mint a token in hyperi-infra's GitHub App Client
IDs workflow.

## Needs doing separately

`GH_APP_PRIVATE_KEY` is visible to 14 repos and **hyperi-ci is not one of them**,
nor is culvert. Until they are added, both take the fallback path and the
warning - so hyperi-ci's own next release will demonstrate the degraded branch
rather than the fixed one. Adding a repo to that secret's selected list is
org-admin work.

Unrelated and untouched: actionlint reports SC2086 on the unquoted `$SUBMODULES`
at line 129. That looks deliberate (word splitting to pass several submodule
paths) so it is left alone rather than changed blind.

Done when a release tail run on a repo carrying required status checks tags and
pushes without being blocked, with the bot as the pusher.
