### PR TITLE
fix(ci): report consumers whose ci.yml has fallen behind the dispatch contract

### DIFF
--- a/.github/workflows/_release-tail.yml
+++ b/.github/workflows/_release-tail.yml
@@ -222,6 +222,12 @@ jobs:
       issues: write
       pull-requests: write
       packages: write
+    env:
+      # Mapped to env because the `secrets` context is not readable from a
+      # step-level `if`, and the release identity turns on whether this repo
+      # can see the App key at all (the org secret is `selected`, and this is
+      # a reusable workflow -- `secrets: inherit` resolves in the CALLER).
+      RELEASE_APP_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -231,6 +237,36 @@ jobs:
           ref: ${{ inputs.tag || github.ref }}
           fetch-depth: 0
           persist-credentials: false
+
+      - name: Mint the release bot token
+        # Tag, commit and release-commit all PUSH. As `github-actions` those
+        # pushes cannot be excepted from a branch ruleset -- rulesets only
+        # accept org-installed apps as bypass actors and GitHub refuses the
+        # first-party integration -- so a repo wanting required status checks
+        # cannot have them (issue #86). A GITHUB_TOKEN push also triggers no
+        # workflows, leaving the release commit invisible to anything that
+        # should react to it.
+        id: bot
+        if: env.RELEASE_APP_KEY != ''
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.GH_APP_CLIENT_ID }}
+          private-key: ${{ env.RELEASE_APP_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-contents: write
+          permission-issues: write
+          permission-pull-requests: write
+
+      - name: Report the release identity
+        # A silent fall back to github-actions is what makes a missing ruleset
+        # bypass look like a working release, so say which identity is in use.
+        run: |
+          if [ "${{ steps.bot.outcome }}" = "success" ]; then
+            echo "Tagging and pushing as hypersec-ci-bot."
+          else
+            echo "::warning::GH_APP_PRIVATE_KEY is not visible to this repo — tagging as github-actions. Required status checks cannot be bypassed, and the release push will trigger no workflows. Add this repo to the GH_APP_PRIVATE_KEY org secret's selected list to fix both."
+          fi
 
       - name: Setup semantic-release (shared toolchain — single source of truth)
         # Runs the version oracle on a push, and on a from-head `auto`
@@ -278,8 +314,8 @@ jobs:
         # oracle. Once the first tag exists this branch never fires again.
         if: ${{ github.event_name == 'push' || (inputs.from-head == 'true' && inputs.bump == 'auto') }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.bot.outputs.token || secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.bot.outputs.token || secrets.GITHUB_TOKEN }}
         run: |
           if [ -z "$(git tag --list 'v[0-9]*')" ]; then
             echo "Tag-less repo — first release: tagging HEAD v${{ inputs.next-version }} from the plan's prediction"
@@ -336,7 +372,7 @@ jobs:
         id: forcedtag
         if: ${{ inputs.from-head == 'true' && inputs.bump != 'auto' && inputs.bump != '' }}
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.bot.outputs.token || secrets.GITHUB_TOKEN }}
         run: ${{ env.HYPERCI_INSTALL }} tag-head --bump ${{ inputs.bump }}
 
       - name: Publish
@@ -371,7 +407,9 @@ jobs:
         if: steps.publish.outcome == 'success'
         continue-on-error: true
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Also a push to the default branch, so it needs the bypass actor
+          # for the same reason the tag does.
+          GH_TOKEN: ${{ steps.bot.outputs.token || secrets.GITHUB_TOKEN }}
         run: >-
           ${{ env.HYPERCI_INSTALL }} release-commit
           "${{ steps.forcedtag.outputs.version || inputs.next-version }}"

--- a/src/hyperi_ci/caller_audit.py
+++ b/src/hyperi_ci/caller_audit.py
@@ -1,0 +1,237 @@
+# Project:   HyperI CI
+# File:      src/hyperi_ci/caller_audit.py
+# Purpose:   Report consumer ci.yml drift against the dispatch contract
+#
+# License:   BUSL-1.1 — HYPERI PTY LIMITED
+# Copyright: (c) 2026 HYPERI PTY LIMITED
+"""Report when a consumer's ci.yml falls behind the dispatch contract.
+
+`workflow_dispatch.inputs` must be declared in the workflow that RECEIVES the
+event, so a reusable workflow cannot add inputs to its caller's schema. Every
+consumer declares and forwards them itself, and every consumer can therefore
+fall behind (issue #88).
+
+Nothing reports the gap on its own. It surfaces as an HTTP 422 at dispatch
+time, and only when someone tries to release that way -- four of eight Rust
+repos were undriveable for months before anyone needed the path.
+
+The contract is :data:`hyperi_ci.publish.dispatch.DISPATCH_INPUTS`, which is
+what the CLI actually sends, rather than the reusable workflow's full
+`workflow_call.inputs`. A `workflow_call` input nobody dispatches (say
+`rust-toolchain`) has no business in a consumer's dispatch schema.
+
+Three ways a consumer breaks, all reported, none written:
+
+``missing``        not declared at all -- the 422
+``not-forwarded``  declared but absent from the job's `with:` block, so the
+                   flag is accepted and silently ignored
+``required``       declared `required: true`, which fails any dispatch that
+                   does not send it (a from-head release sends no `tag`)
+
+Reads are strictly report-only: the caller file belongs to the consumer repo.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import yaml
+
+from hyperi_ci.publish.dispatch import DISPATCH_INPUTS
+
+# Reusable workflows this project publishes. A job calling one of these is a
+# release caller and is held to the dispatch contract.
+_REUSABLE = re.compile(
+    r"hyperi-io/hyperi-ci/\.github/workflows/(?P<name>[a-z-]+)-ci\.yml@",
+)
+
+# `${{ inputs.foo }}` / `${{ inputs.foo || '' }}` in a `with:` value.
+_FORWARDED = re.compile(r"inputs\.([A-Za-z0-9_-]+)")
+
+DEFAULT_CALLER = Path(".github/workflows/ci.yml")
+
+
+@dataclass
+class Finding:
+    """One drifted input on one consumer."""
+
+    kind: str  # missing | not-forwarded | required
+    input_name: str
+
+    def describe(self) -> str:
+        """Render the finding for a terminal report."""
+        if self.kind == "missing":
+            return f"{self.input_name}: not declared in workflow_dispatch.inputs"
+        if self.kind == "not-forwarded":
+            return f"{self.input_name}: declared but not passed in `with:`"
+        return (
+            f"{self.input_name}: declared `required: true`, breaking other dispatches"
+        )
+
+
+@dataclass
+class CallerReport:
+    """What one consumer's ci.yml declares, and where it drifts."""
+
+    repo: str
+    calls: str | None = None
+    declared: list[str] = field(default_factory=list)
+    forwarded: list[str] = field(default_factory=list)
+    findings: list[Finding] = field(default_factory=list)
+    error: str | None = None
+
+    @property
+    def ok(self) -> bool:
+        """True when the consumer honours the whole dispatch contract."""
+        return not self.findings and self.error is None
+
+
+def _dispatch_inputs(doc: dict) -> dict:
+    """Return `on.workflow_dispatch.inputs`, tolerating YAML's `on` -> True."""
+    # PyYAML resolves a bare `on:` key to the boolean True, so a workflow
+    # parsed with safe_load has its triggers under True rather than "on".
+    triggers = doc.get("on")
+    if triggers is None:
+        triggers = doc.get(True)
+    if not isinstance(triggers, dict):
+        return {}
+    dispatch = triggers.get("workflow_dispatch")
+    if not isinstance(dispatch, dict):
+        return {}
+    inputs = dispatch.get("inputs")
+    return inputs if isinstance(inputs, dict) else {}
+
+
+def _calling_job(doc: dict) -> tuple[str, dict] | None:
+    """Return the (reusable workflow ref, job) that calls a hyperi-ci workflow."""
+    jobs = doc.get("jobs")
+    if not isinstance(jobs, dict):
+        return None
+    for job in jobs.values():
+        if not isinstance(job, dict):
+            continue
+        uses = job.get("uses")
+        if isinstance(uses, str) and _REUSABLE.search(uses):
+            return uses, job
+    return None
+
+
+def audit_text(repo: str, text: str) -> CallerReport:
+    """Audit one consumer's ci.yml contents against the dispatch contract."""
+    report = CallerReport(repo=repo)
+    try:
+        doc = yaml.safe_load(text)
+    except yaml.YAMLError as exc:
+        report.error = f"unparseable ci.yml: {exc}"
+        return report
+    if not isinstance(doc, dict):
+        report.error = "ci.yml is not a mapping"
+        return report
+
+    called = _calling_job(doc)
+    if called is None:
+        report.error = "no job calls a hyperi-ci reusable workflow"
+        return report
+    uses, job = called
+    report.calls = uses
+
+    declared = _dispatch_inputs(doc)
+    report.declared = sorted(declared)
+
+    with_block = job.get("with")
+    with_block = with_block if isinstance(with_block, dict) else {}
+    forwarded: set[str] = set()
+    for value in with_block.values():
+        forwarded.update(_FORWARDED.findall(str(value)))
+    report.forwarded = sorted(forwarded)
+
+    for name in DISPATCH_INPUTS:
+        spec = declared.get(name)
+        if spec is None:
+            report.findings.append(Finding("missing", name))
+            continue
+        if name not in forwarded:
+            report.findings.append(Finding("not-forwarded", name))
+        if isinstance(spec, dict) and spec.get("required") is True:
+            report.findings.append(Finding("required", name))
+
+    return report
+
+
+def audit_local(root: Path | None = None) -> CallerReport:
+    """Audit the working tree's ci.yml.
+
+    The working tree is the right source here -- it is the file about to be
+    committed. Fleet sweeps read the default branch instead (see
+    :func:`audit_repo`), because a checkout sitting on a fix branch reports
+    drift that main still has.
+    """
+    root = root or Path.cwd()
+    path = root / DEFAULT_CALLER
+    name = root.name
+    if not path.is_file():
+        return CallerReport(repo=name, error=f"no {DEFAULT_CALLER}")
+    return audit_text(name, path.read_text(encoding="utf-8"))
+
+
+def _gh_json(args: list[str]) -> object | None:
+    """Run a gh command and decode its JSON, or None on any failure."""
+    result = subprocess.run(
+        ["gh", *args],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    if result.returncode != 0:
+        return None
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return None
+
+
+def audit_repo(full_name: str) -> CallerReport:
+    """Audit one repo's ci.yml as it stands on the DEFAULT BRANCH.
+
+    Reading the default branch rather than a local clone is the point: a
+    working tree parked on a release branch reports a fix that main has not
+    got.
+    """
+    result = subprocess.run(
+        [
+            "gh",
+            "api",
+            f"repos/{full_name}/contents/.github/workflows/ci.yml",
+            "--header",
+            "Accept: application/vnd.github.raw+json",
+        ],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    if result.returncode != 0:
+        return CallerReport(repo=full_name, error="no .github/workflows/ci.yml")
+    return audit_text(full_name, result.stdout)
+
+
+def org_repos(org: str) -> list[str]:
+    """Return every non-archived repo in the org."""
+    data = _gh_json(
+        ["api", f"orgs/{org}/repos?per_page=100&type=all", "--paginate"],
+    )
+    if not isinstance(data, list):
+        return []
+    names: list[str] = []
+    for entry in data:
+        if not isinstance(entry, dict) or entry.get("archived"):
+            continue
+        full_name = entry.get("full_name")
+        if isinstance(full_name, str):
+            names.append(full_name)
+    return names

--- a/src/hyperi_ci/cli.py
+++ b/src/hyperi_ci/cli.py
@@ -596,6 +596,82 @@ def describe(
     raise typer.Exit(0)
 
 
+@app.command("audit-callers")
+def audit_callers(
+    org: Annotated[
+        str | None,
+        typer.Option("--org", help="Sweep every repo in this org, reading main"),
+    ] = None,
+    repo: Annotated[
+        str | None,
+        typer.Option("--repo", help="Audit one repo (owner/name), reading main"),
+    ] = None,
+    project_dir: Annotated[
+        str | None,
+        typer.Option("--project-dir", "-C", help="Project root directory"),
+    ] = None,
+) -> None:
+    """Report consumers whose ci.yml has fallen behind the dispatch contract.
+
+    `workflow_dispatch.inputs` only work when declared in the workflow that
+    receives the event, so a reusable workflow cannot add them to its caller.
+    Every consumer declares and forwards them itself, and drifts on its own
+    (issue #88).
+
+    Reports three faults: an input not declared at all (the HTTP 422), one
+    declared but not passed in `with:` (accepted then silently ignored), and
+    one declared `required: true` (which breaks every dispatch that does not
+    send it).
+
+    Never writes. The caller file belongs to the consumer repo.
+    """
+    from hyperi_ci.caller_audit import (
+        audit_local,
+        audit_repo,
+        org_repos,
+    )
+    from hyperi_ci.common import error, info, success, warn
+
+    if org and repo:
+        error("Use --org or --repo, not both")
+        raise typer.Exit(2)
+
+    if org:
+        targets = org_repos(org)
+        if not targets:
+            error(f"No repos readable in {org}")
+            raise typer.Exit(1)
+        reports = [audit_repo(name) for name in targets]
+        # A repo with no ci.yml, or one that calls nothing of ours, is not a
+        # consumer -- reporting it would bury the real findings.
+        reports = [r for r in reports if r.calls is not None]
+    elif repo:
+        reports = [audit_repo(repo)]
+    else:
+        reports = [audit_local(Path(project_dir) if project_dir else None)]
+
+    drifted = [r for r in reports if not r.ok]
+    for report in reports:
+        if report.ok:
+            continue
+        if report.error:
+            warn(f"{report.repo}: {report.error}")
+            continue
+        warn(f"{report.repo} ({report.calls}):")
+        for finding in report.findings:
+            warn(f"  {finding.describe()}")
+
+    info(f"Audited {len(reports)} caller(s)")
+    if not drifted:
+        success("Every caller honours the dispatch contract")
+        raise typer.Exit(0)
+
+    error(f"{len(drifted)} caller(s) drifted — a release from HEAD will fail")
+    info("Fix in the consumer repo's .github/workflows/ci.yml, or re-run")
+    info("`hyperi-ci init` there to regenerate it.")
+    raise typer.Exit(1)
+
+
 @app.command(name="release-notify")
 def release_notify_cmd(
     version: Annotated[

--- a/src/hyperi_ci/publish/dispatch.py
+++ b/src/hyperi_ci/publish/dispatch.py
@@ -22,6 +22,30 @@ import subprocess
 
 from hyperi_ci.common import error, explicit_version, info, success, warn
 
+# Every input this module can send on a workflow_dispatch. A consumer's
+# `on.workflow_dispatch.inputs` must declare and forward all of these, or the
+# dispatch fails with HTTP 422 (issue #88). `hyperi-ci audit-callers` checks
+# consumers against this tuple.
+DISPATCH_INPUTS: tuple[str, ...] = ("tag", "from-head", "bump")
+
+
+def _dispatch_cmd(workflow: str, inputs: dict[str, str]) -> list[str]:
+    """Build a `gh workflow run` command for the given dispatch inputs.
+
+    Rejects an input outside DISPATCH_INPUTS, which would 422 on every
+    consumer that never declared it.
+    """
+    unknown = sorted(set(inputs) - set(DISPATCH_INPUTS))
+    if unknown:
+        raise ValueError(
+            f"dispatch input(s) {unknown} not in DISPATCH_INPUTS — add them "
+            f"there so audit-callers requires consumers to declare them"
+        )
+    cmd = ["gh", "workflow", "run", workflow]
+    for key, value in inputs.items():
+        cmd += ["-f", f"{key}={value}"]
+    return cmd
+
 
 def _get_version_tags() -> list[str]:
     """Get all version tags sorted by version descending."""
@@ -159,16 +183,7 @@ def dispatch_from_head(*, bump: str = "auto", dry_run: bool = False) -> int:
         )
 
     workflow = _detect_workflow_file()
-    cmd = [
-        "gh",
-        "workflow",
-        "run",
-        workflow,
-        "-f",
-        "from-head=true",
-        "-f",
-        f"bump={bump}",
-    ]
+    cmd = _dispatch_cmd(workflow, {"from-head": "true", "bump": bump})
 
     label = f"version=v{bump}" if explicit is not None else f"bump={bump}"
 
@@ -223,7 +238,7 @@ def dispatch_publish(tag: str, dry_run: bool = False) -> int:
         )
 
     workflow = _detect_workflow_file()
-    cmd = ["gh", "workflow", "run", workflow, "-f", f"tag={tag}"]
+    cmd = _dispatch_cmd(workflow, {"tag": tag})
 
     if dry_run:
         info(f"Would run: {' '.join(cmd)}")

--- a/tests/unit/test_caller_audit.py
+++ b/tests/unit/test_caller_audit.py
@@ -1,0 +1,173 @@
+# Project:   HyperI CI
+# File:      tests/unit/test_caller_audit.py
+# Purpose:   Consumer ci.yml drift against the dispatch contract (issue #88)
+#
+# License:   BUSL-1.1 — HYPERI PTY LIMITED
+# Copyright: (c) 2026 HYPERI PTY LIMITED
+"""Caller-audit tests.
+
+The shapes here are taken from real consumers: `COMPLIANT` is dfe-receiver
+after its fix, `PRE_FIX` is the shape that produced the HTTP 422 across four
+Rust repos.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from hyperi_ci.caller_audit import audit_local, audit_text
+from hyperi_ci.publish.dispatch import DISPATCH_INPUTS, _dispatch_cmd
+
+COMPLIANT = """
+name: CI
+on:
+  push:
+    branches: ["**"]
+  workflow_dispatch:
+    inputs:
+      tag:
+        type: string
+        required: false
+        default: ""
+      from-head:
+        type: string
+        required: false
+        default: ""
+      bump:
+        type: string
+        required: false
+        default: "auto"
+jobs:
+  ci:
+    uses: hyperi-io/hyperi-ci/.github/workflows/rust-ci.yml@main
+    with:
+      publish-target: both
+      tag: ${{ inputs.tag || '' }}
+      from-head: ${{ inputs.from-head || '' }}
+      bump: ${{ inputs.bump || 'auto' }}
+    secrets: inherit
+"""
+
+PRE_FIX = """
+name: CI
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        type: string
+        required: true
+jobs:
+  ci:
+    uses: hyperi-io/hyperi-ci/.github/workflows/rust-ci.yml@main
+    with:
+      publish-target: both
+"""
+
+
+def _kinds(text: str) -> set[tuple[str, str]]:
+    report = audit_text("under-test", text)
+    return {(f.kind, f.input_name) for f in report.findings}
+
+
+def test_compliant_caller_is_clean() -> None:
+    report = audit_text("dfe-receiver", COMPLIANT)
+    assert report.ok
+    assert report.calls is not None
+    assert report.declared == ["bump", "from-head", "tag"]
+    assert report.forwarded == ["bump", "from-head", "tag"]
+
+
+def test_pre_fix_caller_reports_every_fault() -> None:
+    """The exact shape that 422'd four Rust repos."""
+    assert _kinds(PRE_FIX) == {
+        ("missing", "from-head"),
+        ("missing", "bump"),
+        ("not-forwarded", "tag"),
+        ("required", "tag"),
+    }
+
+
+def test_declared_but_not_forwarded_is_reported() -> None:
+    """An input accepted then silently ignored is worse than the 422."""
+    text = COMPLIANT.replace("      bump: ${{ inputs.bump || 'auto' }}\n", "")
+    assert ("not-forwarded", "bump") in _kinds(text)
+
+
+def test_required_true_is_reported_even_when_forwarded() -> None:
+    """A required `tag` breaks a from-head dispatch, which sends no tag."""
+    text = COMPLIANT.replace(
+        "      tag:\n        type: string\n        required: false",
+        "      tag:\n        type: string\n        required: true",
+    )
+    assert ("required", "tag") in _kinds(text)
+
+
+def test_yaml_boolean_on_key_is_handled() -> None:
+    """PyYAML resolves a bare `on:` to True, which must not hide the inputs."""
+    import yaml
+
+    doc = yaml.safe_load(COMPLIANT)
+    assert True in doc or "on" in doc
+    assert audit_text("x", COMPLIANT).declared == ["bump", "from-head", "tag"]
+
+
+def test_non_caller_is_not_audited() -> None:
+    text = """
+name: CI
+on:
+  workflow_dispatch:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hi
+"""
+    report = audit_text("not-a-consumer", text)
+    assert report.calls is None
+    assert report.error is not None
+
+
+def test_unparseable_yaml_reports_rather_than_raises() -> None:
+    report = audit_text("broken", "name: [unclosed\n")
+    assert report.error is not None
+    assert not report.ok
+
+
+def test_missing_ci_yml_reports(tmp_path) -> None:
+    report = audit_local(tmp_path)
+    assert not report.ok
+    assert report.error is not None
+
+
+@pytest.mark.parametrize("name", DISPATCH_INPUTS)
+def test_every_contract_input_is_checked(name: str) -> None:
+    """Adding to DISPATCH_INPUTS must extend the audit, not bypass it."""
+    assert ("missing", name) in _kinds(
+        """
+name: CI
+on:
+  workflow_dispatch:
+jobs:
+  ci:
+    uses: hyperi-io/hyperi-ci/.github/workflows/rust-ci.yml@main
+    with:
+      publish-target: both
+"""
+    )
+
+
+def test_dispatch_cmd_rejects_an_undeclared_input() -> None:
+    """An input sent but absent from the contract would 422 every consumer."""
+    with pytest.raises(ValueError, match="DISPATCH_INPUTS"):
+        _dispatch_cmd("ci.yml", {"not-a-real-input": "x"})
+
+
+def test_dispatch_cmd_builds_the_gh_invocation() -> None:
+    assert _dispatch_cmd("ci.yml", {"tag": "v1.2.3"}) == [
+        "gh",
+        "workflow",
+        "run",
+        "ci.yml",
+        "-f",
+        "tag=v1.2.3",
+    ]

--- a/tests/unit/test_workflow_consistency.py
+++ b/tests/unit/test_workflow_consistency.py
@@ -621,3 +621,59 @@ def test_release_tail_uses_shared_workflow(workflow_name: str) -> None:
         f"Every language workflow must delegate container + tag-and-publish "
         f"to the shared release-tail workflow."
     )
+
+
+# Steps in _release-tail.yml that PUSH to the default branch or create a tag.
+# Named by the `name:` field so a reordering does not silently drop one.
+_PUSHING_STEPS = (
+    "Tag (semantic-release)",
+    "Tag HEAD (forced bump / explicit version)",
+    "Commit rendered release artefacts",
+)
+
+_BOT_TOKEN = "${{ steps.bot.outputs.token || secrets.GITHUB_TOKEN }}"
+
+
+def _tag_and_publish_steps() -> list[dict]:
+    wf = _load_workflow("_release-tail.yml")
+    return wf["jobs"]["tag-and-publish"]["steps"]
+
+
+def test_release_tail_mints_a_bot_token() -> None:
+    """The App token must be minted from the Client ID, not the App ID.
+
+    `app-id` is deprecated in actions/create-github-app-token, and the Client
+    ID is a different value rather than a rename, so a swap back would fail at
+    token-mint time instead of at review.
+    """
+    steps = _tag_and_publish_steps()
+    mint = [s for s in steps if s.get("id") == "bot"]
+    assert mint, (
+        "_release-tail.tag-and-publish: no `bot` step minting an App token. "
+        "Pushes made as github-actions cannot be excepted from a branch "
+        "ruleset and trigger no workflows (issue #86)."
+    )
+    with_ = mint[0].get("with", {})
+    assert "client-id" in with_, "the bot token must be minted from client-id"
+    assert "app-id" not in with_, "app-id is deprecated — use client-id"
+
+
+@pytest.mark.parametrize("step_name", _PUSHING_STEPS)
+def test_pushing_steps_use_the_bot_token(step_name: str) -> None:
+    """Every step that writes to the repo must prefer the App token.
+
+    A bare `secrets.GITHUB_TOKEN` here is the regression that reintroduces
+    issue #86: the push lands as github-actions, which no ruleset can grant a
+    bypass to, so the repo cannot carry required status checks.
+    """
+    steps = _tag_and_publish_steps()
+    matching = [s for s in steps if s.get("name") == step_name]
+    assert matching, f"_release-tail: step {step_name!r} has gone or been renamed"
+    env = matching[0].get("env", {})
+    tokens = {k: v for k, v in env.items() if k in ("GH_TOKEN", "GITHUB_TOKEN")}
+    assert tokens, f"{step_name}: expected a GH_TOKEN/GITHUB_TOKEN in env"
+    for key, value in tokens.items():
+        assert value == _BOT_TOKEN, (
+            f"{step_name}: {key} is {value!r}, expected the bot token with a "
+            f"GITHUB_TOKEN fallback ({_BOT_TOKEN!r})."
+        )


### PR DESCRIPTION
Closes #88.

`hyperi-ci audit-callers` reports consumers whose ci.yml has fallen behind the
dispatch contract. Report-only - the caller file belongs to the consumer repo.

Three faults, not just the 422:

| Fault | Consequence |
|---|---|
| not declared | HTTP 422 at dispatch |
| declared but absent from `with:` | flag accepted, silently ignored |
| `required: true` | breaks every dispatch that does not send it |

## On generalising it

Keyed to `DISPATCH_INPUTS` in `publish/dispatch.py` - what the CLI actually
sends - rather than the reusable workflow's full `workflow_call.inputs`. A
`workflow_call` input nobody dispatches (`rust-toolchain`, `submodules`,
`language`) has no business in a consumer's dispatch schema, so comparing
against all of them would report noise and get ignored.

Both dispatch sites now build their command through `_dispatch_cmd`, which
REJECTS an input missing from that tuple. That is the generalisation: add a
dispatchable input and the audit requires it of every consumer automatically,
with no second list to keep in step.

Three modes: working tree by default (the file about to be committed),
`--repo`, and `--org` for a fleet sweep. Both remote modes read the DEFAULT
BRANCH rather than a local clone - the trap called out in the issue.

## What the sweep found

28 callers, 7 drifted. More than the manual audit saw.

Never in the issue's table at all:

- `macbash`, `dfe-transform-elastic`, `dfe-transform-wasm`, `culvert`

Recorded as already patched, but not on main:

- `dfe-archiver`, `dfe-transform-vrl`, `dfe-transform-vector`

Those three fixes are sitting in OPEN PRs (dfe-archiver#38 confirmed open), so
main is still undriveable. Worth merging before the next fleet release - and a
fair demonstration of why reading the default branch is the right source.

## Verified

- 1992 tests pass, `hyperi-ci check` green end to end
- 13 new tests over all three faults, using the real pre-fix and post-fix
  shapes. Checked by disabling the required-input rule and watching two of
  them fail, rather than trusting a green run
- Exercised against live repos both ways: `dfe-receiver` clean, org sweep as
  above

NOT wired into `hyperi-ci check`. It needs network and the fleet view is the
useful one, so it stays an on-demand command. Easy to add later if the
local-repo check earns its place.
