### PR TITLE
fix(ci): route renovate Rust PRs to a runner that has cargo

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -207,11 +207,18 @@ jobs:
         # validate-only AND branch-mode PR builds — arm64 is slow on
         # shared runners and wasteful when nothing's being shipped, so
         # arch breadth keys off will-publish, NOT run-build.
+        #
+        # The renovate/ carve-out must land on a runner with cargo: Rust does
+        # not bootstrap its toolchain at job time, and GH_RUNNER_RENOVATE /
+        # GH_RUNNER_DEFAULT point at vanilla sets that carry none (issue #91).
+        # Chain: GH_RUNNER_RENOVATE_RUST (set e.g. arc-native-4cpu to shed
+        # bot load) -> GH_RUNNER_RUST -> hosted ubuntu-latest, which ships
+        # cargo.
         id: matrix
         shell: bash
         run: |
           set -euo pipefail
-          AMD64_RUNNER="${{ startsWith(github.head_ref || github.ref_name, 'renovate/') && (vars.GH_RUNNER_RENOVATE || 'ubuntu-latest') || (inputs.runner-mode || vars.GH_RUNNER_MODE) == 'free' && 'ubuntu-latest' || inputs.runner-build || vars.GH_RUNNER_RUST || vars.GH_RUNNER_DEFAULT || 'ubuntu-latest' }}"
+          AMD64_RUNNER="${{ startsWith(github.head_ref || github.ref_name, 'renovate/') && (vars.GH_RUNNER_RENOVATE_RUST || vars.GH_RUNNER_RUST || 'ubuntu-latest') || (inputs.runner-mode || vars.GH_RUNNER_MODE) == 'free' && 'ubuntu-latest' || inputs.runner-build || vars.GH_RUNNER_RUST || vars.GH_RUNNER_DEFAULT || 'ubuntu-latest' }}"
           ARM64_RUNNER="${{ vars.GH_RUNNER_ARM64 || 'ubuntu-24.04-arm' }}"
           if [[ "${{ steps.predict.outputs.will-publish }}" == "true" ]]; then
             matrix='{"include":[{"target":"x86_64-unknown-linux-gnu","runner":"'"$AMD64_RUNNER"'","os_arch":"linux-amd64"},{"target":"aarch64-unknown-linux-gnu","runner":"'"$ARM64_RUNNER"'","os_arch":"linux-arm64"}]}'
@@ -249,7 +256,7 @@ jobs:
     needs: [plan]
     if: needs.plan.outputs.run-checks == 'true'
     # Renovate branches use lightweight runners — dependency update PRs don't need 16cpu
-    runs-on: ${{ startsWith(github.head_ref || github.ref_name, 'renovate/') && (vars.GH_RUNNER_RENOVATE || 'ubuntu-latest') || (inputs.runner-mode || vars.GH_RUNNER_MODE) == 'free' && 'ubuntu-latest' || inputs.runner-quality || vars.GH_RUNNER_RUST || vars.GH_RUNNER_DEFAULT || 'ubuntu-latest' }}
+    runs-on: ${{ startsWith(github.head_ref || github.ref_name, 'renovate/') && (vars.GH_RUNNER_RENOVATE_RUST || vars.GH_RUNNER_RUST || 'ubuntu-latest') || (inputs.runner-mode || vars.GH_RUNNER_MODE) == 'free' && 'ubuntu-latest' || inputs.runner-quality || vars.GH_RUNNER_RUST || vars.GH_RUNNER_DEFAULT || 'ubuntu-latest' }}
     steps:
       - name: Docker Hub login
         if: ${{ vars.DOCKERHUB_USERNAME != '' }}
@@ -319,7 +326,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ${{ fromJson(startsWith(github.head_ref || github.ref_name, 'renovate/') && format('["{0}"]', vars.GH_RUNNER_RENOVATE || 'ubuntu-latest') || (inputs.runner-mode || vars.GH_RUNNER_MODE) == 'free' && '["ubuntu-latest"]' || inputs.test-matrix || format('["{0}"]', inputs.runner-test || vars.GH_RUNNER_RUST || vars.GH_RUNNER_DEFAULT || 'ubuntu-latest')) }}
+        os: ${{ fromJson(startsWith(github.head_ref || github.ref_name, 'renovate/') && format('["{0}"]', vars.GH_RUNNER_RENOVATE_RUST || vars.GH_RUNNER_RUST || 'ubuntu-latest') || (inputs.runner-mode || vars.GH_RUNNER_MODE) == 'free' && '["ubuntu-latest"]' || inputs.test-matrix || format('["{0}"]', inputs.runner-test || vars.GH_RUNNER_RUST || vars.GH_RUNNER_DEFAULT || 'ubuntu-latest')) }}
     steps:
       - name: Docker Hub login
         if: ${{ vars.DOCKERHUB_USERNAME != '' }}

--- a/tests/unit/test_workflow_consistency.py
+++ b/tests/unit/test_workflow_consistency.py
@@ -623,6 +623,30 @@ def test_release_tail_uses_shared_workflow(workflow_name: str) -> None:
     )
 
 
+def test_rust_renovate_carveout_never_lands_on_a_toolchainless_runner() -> None:
+    """issue #91: renovate/ branches must resolve to a runner with cargo.
+
+    GH_RUNNER_RENOVATE and GH_RUNNER_DEFAULT point at vanilla sets, and Rust
+    does not bootstrap its toolchain at job time — so rust-ci.yml's renovate
+    carve-out must chain GH_RUNNER_RENOVATE_RUST -> GH_RUNNER_RUST, never the
+    shared GH_RUNNER_RENOVATE.
+    """
+    import re
+
+    text = (WORKFLOW_DIR / "rust-ci.yml").read_text(encoding="utf-8")
+    expressions = [line for line in text.splitlines() if "renovate/" in line and "${{" in line]
+    assert expressions, "rust-ci.yml: the renovate carve-out has vanished entirely"
+    for line in expressions:
+        assert not re.search(r"GH_RUNNER_RENOVATE(?!_RUST)", line), (
+            f"rust-ci.yml routes a renovate/ branch through the shared "
+            f"GH_RUNNER_RENOVATE (a vanilla set with no cargo): {line.strip()}"
+        )
+        assert "GH_RUNNER_RUST" in line, (
+            f"rust-ci.yml renovate carve-out must fall back to GH_RUNNER_RUST: "
+            f"{line.strip()}"
+        )
+
+
 # Steps in _release-tail.yml that PUSH to the default branch or create a tag.
 # Named by the `name:` field so a reordering does not silently drop one.
 _PUSHING_STEPS = (


### PR DESCRIPTION
Closes #91.

The diagnosis in the issue was wrong in a useful way: `GH_RUNNER_RUST` never came back empty. On a `renovate/` branch the expression short-circuits into a deliberate carve-out before consulting it - `GH_RUNNER_RENOVATE` = `arc-vanilla-4cpu`, which only LOOKED like the `GH_RUNNER_DEFAULT` fallback because both vars hold the same value. The carve-out is a cost lever (keep bot PRs off the 16-core estate) and it works for python/ts/go, which install their toolchains at job time. Rust relies on the pre-baked estate, so vanilla can never work for it.

The carve-out stays, but Rust resolves through its own chain: `GH_RUNNER_RENOVATE_RUST -> GH_RUNNER_RUST -> ubuntu-latest` (hosted ships cargo), deliberately skipping both vanilla vars. `GH_RUNNER_RENOVATE_RUST` is left unset, so bot PRs land on `arc-native-16cpu` exactly as the issue's done-when asks; set it to a smaller native set only if bot load on the 16-core set ever matters.

All three resolution sites move together (plan matrix, quality, test), pinned by a consistency test that rejects any `renovate/` expression in rust-ci.yml referencing the shared `GH_RUNNER_RENOVATE` - checked by reverting one site and watching it fail.

The stale `GH_RUNNER_DEFAULT=arc-runner-16cpu` repo vars on dfe-receiver/dfe-loader are already gone - both repos report zero repo variables via the API.

Workflows float `@main`, so merging IS the rollout. Done-when verification after merge: re-run a renovate Rust PR and read `AMD64_RUNNER=` in its Plan log.