### PR TITLE
fix(ci): survive a missing cargo, and route renovate Rust to a runner with one

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -207,11 +207,18 @@ jobs:
         # validate-only AND branch-mode PR builds — arm64 is slow on
         # shared runners and wasteful when nothing's being shipped, so
         # arch breadth keys off will-publish, NOT run-build.
+        #
+        # The renovate/ carve-out must land on a runner with cargo: Rust does
+        # not bootstrap its toolchain at job time, and GH_RUNNER_RENOVATE /
+        # GH_RUNNER_DEFAULT point at vanilla sets that carry none (issue #91).
+        # Chain: GH_RUNNER_RENOVATE_RUST (set e.g. arc-native-4cpu to shed
+        # bot load) -> GH_RUNNER_RUST -> hosted ubuntu-latest, which ships
+        # cargo.
         id: matrix
         shell: bash
         run: |
           set -euo pipefail
-          AMD64_RUNNER="${{ startsWith(github.head_ref || github.ref_name, 'renovate/') && (vars.GH_RUNNER_RENOVATE || 'ubuntu-latest') || (inputs.runner-mode || vars.GH_RUNNER_MODE) == 'free' && 'ubuntu-latest' || inputs.runner-build || vars.GH_RUNNER_RUST || vars.GH_RUNNER_DEFAULT || 'ubuntu-latest' }}"
+          AMD64_RUNNER="${{ startsWith(github.head_ref || github.ref_name, 'renovate/') && (vars.GH_RUNNER_RENOVATE_RUST || vars.GH_RUNNER_RUST || 'ubuntu-latest') || (inputs.runner-mode || vars.GH_RUNNER_MODE) == 'free' && 'ubuntu-latest' || inputs.runner-build || vars.GH_RUNNER_RUST || vars.GH_RUNNER_DEFAULT || 'ubuntu-latest' }}"
           ARM64_RUNNER="${{ vars.GH_RUNNER_ARM64 || 'ubuntu-24.04-arm' }}"
           if [[ "${{ steps.predict.outputs.will-publish }}" == "true" ]]; then
             matrix='{"include":[{"target":"x86_64-unknown-linux-gnu","runner":"'"$AMD64_RUNNER"'","os_arch":"linux-amd64"},{"target":"aarch64-unknown-linux-gnu","runner":"'"$ARM64_RUNNER"'","os_arch":"linux-arm64"}]}'
@@ -249,7 +256,7 @@ jobs:
     needs: [plan]
     if: needs.plan.outputs.run-checks == 'true'
     # Renovate branches use lightweight runners — dependency update PRs don't need 16cpu
-    runs-on: ${{ startsWith(github.head_ref || github.ref_name, 'renovate/') && (vars.GH_RUNNER_RENOVATE || 'ubuntu-latest') || (inputs.runner-mode || vars.GH_RUNNER_MODE) == 'free' && 'ubuntu-latest' || inputs.runner-quality || vars.GH_RUNNER_RUST || vars.GH_RUNNER_DEFAULT || 'ubuntu-latest' }}
+    runs-on: ${{ startsWith(github.head_ref || github.ref_name, 'renovate/') && (vars.GH_RUNNER_RENOVATE_RUST || vars.GH_RUNNER_RUST || 'ubuntu-latest') || (inputs.runner-mode || vars.GH_RUNNER_MODE) == 'free' && 'ubuntu-latest' || inputs.runner-quality || vars.GH_RUNNER_RUST || vars.GH_RUNNER_DEFAULT || 'ubuntu-latest' }}
     steps:
       - name: Docker Hub login
         if: ${{ vars.DOCKERHUB_USERNAME != '' }}
@@ -319,7 +326,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ${{ fromJson(startsWith(github.head_ref || github.ref_name, 'renovate/') && format('["{0}"]', vars.GH_RUNNER_RENOVATE || 'ubuntu-latest') || (inputs.runner-mode || vars.GH_RUNNER_MODE) == 'free' && '["ubuntu-latest"]' || inputs.test-matrix || format('["{0}"]', inputs.runner-test || vars.GH_RUNNER_RUST || vars.GH_RUNNER_DEFAULT || 'ubuntu-latest')) }}
+        os: ${{ fromJson(startsWith(github.head_ref || github.ref_name, 'renovate/') && format('["{0}"]', vars.GH_RUNNER_RENOVATE_RUST || vars.GH_RUNNER_RUST || 'ubuntu-latest') || (inputs.runner-mode || vars.GH_RUNNER_MODE) == 'free' && '["ubuntu-latest"]' || inputs.test-matrix || format('["{0}"]', inputs.runner-test || vars.GH_RUNNER_RUST || vars.GH_RUNNER_DEFAULT || 'ubuntu-latest')) }}
     steps:
       - name: Docker Hub login
         if: ${{ vars.DOCKERHUB_USERNAME != '' }}

--- a/src/hyperi_ci/native_deps.py
+++ b/src/hyperi_ci/native_deps.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import os
 import platform
+import shutil
 import subprocess
 import sys
 import urllib.error
@@ -644,9 +645,6 @@ def _install_language_tools(language: str) -> int:
     if platform.system() != "Linux":
         return 0
 
-    import os
-    import shutil
-
     for tool in tools:
         # Ensure the tool's install dir is on PATH before probe + install
         bin_dir = Path.home() / tool.bin_dir
@@ -659,6 +657,17 @@ def _install_language_tools(language: str) -> int:
             continue
 
         cmd = [*tool.installer, *tool.args]
+
+        # A missing installer raises FileNotFoundError before the process
+        # starts, which `check=False` does not cover (issue #91). Rust reaches
+        # here before `Install Rust toolchain` runs, so cargo may not exist.
+        if shutil.which(cmd[0]) is None:
+            logger.warning(
+                f"[{tool.name}] {cmd[0]} not on PATH — skipping; dependent CI "
+                "stages will handle the missing tool"
+            )
+            continue
+
         logger.info(f"Installing {tool.name}: {' '.join(cmd)}")
         result = subprocess.run(cmd, check=False)
         if result.returncode != 0:

--- a/tests/unit/test_native_deps.py
+++ b/tests/unit/test_native_deps.py
@@ -731,3 +731,51 @@ class TestAllModeBypass:
         )
         assert rc == 0
         assert installed_packages == []
+
+
+class TestLanguageToolInstallerAbsent:
+    """issue #91: a missing installer degrades, it does not crash.
+
+    `install_language_tools` documents itself as non-fatal, but
+    `subprocess.run(..., check=False)` only suppresses a non-zero EXIT --
+    a missing executable raises FileNotFoundError before the process starts.
+    Rust reaches this before the workflow installs rustup.
+    """
+
+    def test_missing_installer_binary_warns_and_continues(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(native_deps.platform, "system", lambda: "Linux")
+        # cargo absent, and the tool it would install is absent too.
+        monkeypatch.setattr(native_deps.shutil, "which", lambda _cmd: None)
+
+        def explode(*_args: object, **_kwargs: object) -> None:
+            raise AssertionError("must not invoke a missing installer")
+
+        monkeypatch.setattr(native_deps.subprocess, "run", explode)
+
+        assert native_deps._install_language_tools("rust") == 0
+
+    def test_present_installer_is_still_invoked(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The skip stays narrow -- a real cargo still installs the tool."""
+        monkeypatch.setattr(native_deps.platform, "system", lambda: "Linux")
+        monkeypatch.setattr(
+            native_deps.shutil,
+            "which",
+            lambda cmd: "/usr/bin/cargo" if cmd == "cargo" else None,
+        )
+        calls: list[list[str]] = []
+
+        def fake_run(cmd: list[str], **_kwargs: object) -> subprocess.CompletedProcess:
+            calls.append(cmd)
+            return subprocess.CompletedProcess(cmd, 0)
+
+        monkeypatch.setattr(native_deps.subprocess, "run", fake_run)
+
+        assert native_deps._install_language_tools("rust") == 0
+        assert calls, "a present cargo must still be invoked"
+        assert calls[0][0] == "cargo"

--- a/tests/unit/test_workflow_consistency.py
+++ b/tests/unit/test_workflow_consistency.py
@@ -623,6 +623,32 @@ def test_release_tail_uses_shared_workflow(workflow_name: str) -> None:
     )
 
 
+def test_rust_renovate_carveout_never_lands_on_a_toolchainless_runner() -> None:
+    """issue #91: renovate/ branches must resolve to a runner with cargo.
+
+    GH_RUNNER_RENOVATE and GH_RUNNER_DEFAULT point at vanilla sets, and Rust
+    does not bootstrap its toolchain at job time — so rust-ci.yml's renovate
+    carve-out must chain GH_RUNNER_RENOVATE_RUST -> GH_RUNNER_RUST, never the
+    shared GH_RUNNER_RENOVATE.
+    """
+    import re
+
+    text = (WORKFLOW_DIR / "rust-ci.yml").read_text(encoding="utf-8")
+    expressions = [
+        line for line in text.splitlines() if "renovate/" in line and "${{" in line
+    ]
+    assert expressions, "rust-ci.yml: the renovate carve-out has vanished entirely"
+    for line in expressions:
+        assert not re.search(r"GH_RUNNER_RENOVATE(?!_RUST)", line), (
+            f"rust-ci.yml routes a renovate/ branch through the shared "
+            f"GH_RUNNER_RENOVATE (a vanilla set with no cargo): {line.strip()}"
+        )
+        assert "GH_RUNNER_RUST" in line, (
+            f"rust-ci.yml renovate carve-out must fall back to GH_RUNNER_RUST: "
+            f"{line.strip()}"
+        )
+
+
 # Steps in _release-tail.yml that PUSH to the default branch or create a tag.
 # Named by the `name:` field so a reordering does not silently drop one.
 _PUSHING_STEPS = (


### PR DESCRIPTION
Closes #91.

Two defects, either of which alone would have turned every Rust Renovate PR
red.

## The crash

`_install_language_tools` probes for the TOOL it installs (`cargo-pgo`) and
never for the INSTALLER (`cargo`), then calls
`subprocess.run(["cargo", ...], check=False)`. `check=False` suppresses a
non-zero exit, **not** a missing executable — Python raises
`FileNotFoundError` before the process ever starts.

So it crashed in exactly the case its own docstring calls survivable:

> Non-fatal: install failure logs a warning and continues. Downstream stages
> that depend on the tool handle missing-tool fallback.

It now skips with a warning when the installer is absent. This is the fix that
matters: it makes setup-runtime robust on *any* runner, independent of how the
runner was chosen.

## The routing

The issue's diagnosis — "only `GH_RUNNER_RUST` came back empty" — was wrong in
a useful way. The expression never consults `GH_RUNNER_RUST` on a `renovate/`
branch at all; it short-circuits into the carve-out first. It only *looked*
like a fallback because `GH_RUNNER_RENOVATE` and `GH_RUNNER_DEFAULT` hold the
same value.

The carve-out is a legitimate cost lever and it stays. Verified it is correct
for the other three languages — python, ts and go all install their toolchain
at job time (`setup-uv`, `setup-node`, `setup-go`), so vanilla genuinely suits
them and native would make every bot PR pull the ~21GB image for nothing. Rust
is the only language relying on the baked estate.

Rust now resolves `GH_RUNNER_RENOVATE_RUST -> GH_RUNNER_RUST ->
ubuntu-latest`, skipping both vanilla vars. Left unset, bot PRs land on
`arc-native-16cpu` exactly as a human's do — the issue's done-when.

**Worth setting `GH_RUNNER_RENOVATE_RUST = arc-native-4cpu`** if you want the
cost lever to actually bite for Rust: cargo baked, caches warm, and off the
six-slot 16-core set that release builds contend for.

## Incidental

`shutil` moves to a module-level import. The function-local `import os` /
`import shutil` shadowed module imports that already existed, and made the
probe unpatchable from a test.

## Verified

- 1891 tests pass; `hyperi-ci check --quick` clean
- New tests pin both halves — the installer-absent skip, and that no
  `renovate/` expression in rust-ci.yml may reference the shared
  `GH_RUNNER_RENOVATE`. Checked by disabling each and watching the matching
  case fail, not by trusting a green run
- The stale `GH_RUNNER_DEFAULT=arc-runner-16cpu` repo vars on dfe-receiver /
  dfe-loader are already gone — both report zero repo variables via the API

NOT verified: a live renovate Rust PR. Workflows float `@main`, so merging is
the rollout; the done-when check is re-running one and reading `AMD64_RUNNER=`
in its Plan log.

## Adjacent rot, not fixed here

`Install Rust toolchain` is gated on `!contains(runner.name, 'arc-runner')`.
The current scale sets are named `arc-vanilla-4cpu-…`, `arc-native-16cpu-…`,
none of which contain the substring `arc-runner` — so the guard is always true
and the step now runs even on native, redundantly installing rustup over the
baked estate. Same rename rot as the repo vars the issue flagged. Harmless
today, worth its own issue.
