### PR TITLE
fix(ci): gate ARC steps on runner.environment, and rename upgrade -> update

### DIFF
--- a/.github/actions/setup-runtime/action.yml
+++ b/.github/actions/setup-runtime/action.yml
@@ -39,7 +39,7 @@ runs:
   using: composite
   steps:
     - name: Install uv
-      if: ${{ !contains(runner.name, 'arc-runner') }}
+      if: ${{ runner.environment != 'self-hosted' }}
       uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
       with:
         enable-cache: ${{ inputs.enable-uv-cache }}

--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -245,7 +245,7 @@ jobs:
           ref: ${{ inputs.tag || github.ref }}
 
       - name: Set up Go
-        if: ${{ !contains(runner.name, 'arc-runner') }}
+        if: ${{ runner.environment != 'self-hosted' }}
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: ${{ inputs.go-version-file }}
@@ -254,7 +254,7 @@ jobs:
         uses: hyperi-io/hyperi-ci/.github/actions/setup-go-tools@main
 
       - name: Install uv
-        if: ${{ !contains(runner.name, 'arc-runner') }}
+        if: ${{ runner.environment != 'self-hosted' }}
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           enable-cache: false
@@ -301,13 +301,13 @@ jobs:
           ref: ${{ inputs.tag || github.ref }}
 
       - name: Set up Go
-        if: ${{ !contains(runner.name, 'arc-runner') }}
+        if: ${{ runner.environment != 'self-hosted' }}
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: ${{ inputs.go-version-file }}
 
       - name: Install uv
-        if: ${{ !contains(runner.name, 'arc-runner') }}
+        if: ${{ runner.environment != 'self-hosted' }}
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           enable-cache: false
@@ -371,13 +371,13 @@ jobs:
           fi
 
       - name: Set up Go
-        if: ${{ !contains(runner.name, 'arc-runner') }}
+        if: ${{ runner.environment != 'self-hosted' }}
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: ${{ inputs.go-version-file }}
 
       - name: Install uv
-        if: ${{ !contains(runner.name, 'arc-runner') }}
+        if: ${{ runner.environment != 'self-hosted' }}
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           enable-cache: false

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -228,7 +228,7 @@ jobs:
           ref: ${{ inputs.tag || github.ref }}
 
       - name: Install uv
-        if: ${{ !contains(runner.name, 'arc-runner') }}
+        if: ${{ runner.environment != 'self-hosted' }}
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           enable-cache: true
@@ -283,7 +283,7 @@ jobs:
           ref: ${{ inputs.tag || github.ref }}
 
       - name: Install uv
-        if: ${{ !contains(runner.name, 'arc-runner') }}
+        if: ${{ runner.environment != 'self-hosted' }}
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           enable-cache: true
@@ -360,7 +360,7 @@ jobs:
           fi
 
       - name: Install uv
-        if: ${{ !contains(runner.name, 'arc-runner') }}
+        if: ${{ runner.environment != 'self-hosted' }}
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           enable-cache: true

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -275,14 +275,14 @@ jobs:
           language: rust
 
       - name: Install Rust toolchain
-        if: ${{ !contains(runner.name, 'arc-runner') }}
+        if: ${{ runner.environment != 'self-hosted' }}
         uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
         with:
           toolchain: ${{ inputs.rust-toolchain }}
           components: clippy, rustfmt
 
       - name: Cache cargo
-        if: ${{ !contains(runner.name, 'arc-runner') }}
+        if: ${{ runner.environment != 'self-hosted' }}
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           # NOT ~/.cargo/bin/ in THIS job: it only ever held cargo-audit /
@@ -345,13 +345,13 @@ jobs:
           language: rust
 
       - name: Install Rust toolchain
-        if: ${{ !contains(runner.name, 'arc-runner') }}
+        if: ${{ runner.environment != 'self-hosted' }}
         uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
         with:
           toolchain: ${{ inputs.rust-toolchain }}
 
       - name: Cache cargo
-        if: ${{ !contains(runner.name, 'arc-runner') }}
+        if: ${{ runner.environment != 'self-hosted' }}
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
@@ -437,13 +437,13 @@ jobs:
           language: rust
 
       - name: Install Rust toolchain
-        if: ${{ !contains(runner.name, 'arc-runner') }}
+        if: ${{ runner.environment != 'self-hosted' }}
         uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
         with:
           toolchain: ${{ inputs.rust-toolchain }}
 
       - name: Cache cargo
-        if: ${{ !contains(runner.name, 'arc-runner') }}
+        if: ${{ runner.environment != 'self-hosted' }}
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -207,11 +207,18 @@ jobs:
         # validate-only AND branch-mode PR builds — arm64 is slow on
         # shared runners and wasteful when nothing's being shipped, so
         # arch breadth keys off will-publish, NOT run-build.
+        #
+        # The renovate/ carve-out must land on a runner with cargo: Rust does
+        # not bootstrap its toolchain at job time, and GH_RUNNER_RENOVATE /
+        # GH_RUNNER_DEFAULT point at vanilla sets that carry none (issue #91).
+        # Chain: GH_RUNNER_RENOVATE_RUST (set e.g. arc-native-4cpu to shed
+        # bot load) -> GH_RUNNER_RUST -> hosted ubuntu-latest, which ships
+        # cargo.
         id: matrix
         shell: bash
         run: |
           set -euo pipefail
-          AMD64_RUNNER="${{ startsWith(github.head_ref || github.ref_name, 'renovate/') && (vars.GH_RUNNER_RENOVATE || 'ubuntu-latest') || (inputs.runner-mode || vars.GH_RUNNER_MODE) == 'free' && 'ubuntu-latest' || inputs.runner-build || vars.GH_RUNNER_RUST || vars.GH_RUNNER_DEFAULT || 'ubuntu-latest' }}"
+          AMD64_RUNNER="${{ startsWith(github.head_ref || github.ref_name, 'renovate/') && (vars.GH_RUNNER_RENOVATE_RUST || vars.GH_RUNNER_RUST || 'ubuntu-latest') || (inputs.runner-mode || vars.GH_RUNNER_MODE) == 'free' && 'ubuntu-latest' || inputs.runner-build || vars.GH_RUNNER_RUST || vars.GH_RUNNER_DEFAULT || 'ubuntu-latest' }}"
           ARM64_RUNNER="${{ vars.GH_RUNNER_ARM64 || 'ubuntu-24.04-arm' }}"
           if [[ "${{ steps.predict.outputs.will-publish }}" == "true" ]]; then
             matrix='{"include":[{"target":"x86_64-unknown-linux-gnu","runner":"'"$AMD64_RUNNER"'","os_arch":"linux-amd64"},{"target":"aarch64-unknown-linux-gnu","runner":"'"$ARM64_RUNNER"'","os_arch":"linux-arm64"}]}'
@@ -249,7 +256,7 @@ jobs:
     needs: [plan]
     if: needs.plan.outputs.run-checks == 'true'
     # Renovate branches use lightweight runners — dependency update PRs don't need 16cpu
-    runs-on: ${{ startsWith(github.head_ref || github.ref_name, 'renovate/') && (vars.GH_RUNNER_RENOVATE || 'ubuntu-latest') || (inputs.runner-mode || vars.GH_RUNNER_MODE) == 'free' && 'ubuntu-latest' || inputs.runner-quality || vars.GH_RUNNER_RUST || vars.GH_RUNNER_DEFAULT || 'ubuntu-latest' }}
+    runs-on: ${{ startsWith(github.head_ref || github.ref_name, 'renovate/') && (vars.GH_RUNNER_RENOVATE_RUST || vars.GH_RUNNER_RUST || 'ubuntu-latest') || (inputs.runner-mode || vars.GH_RUNNER_MODE) == 'free' && 'ubuntu-latest' || inputs.runner-quality || vars.GH_RUNNER_RUST || vars.GH_RUNNER_DEFAULT || 'ubuntu-latest' }}
     steps:
       - name: Docker Hub login
         if: ${{ vars.DOCKERHUB_USERNAME != '' }}
@@ -319,7 +326,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ${{ fromJson(startsWith(github.head_ref || github.ref_name, 'renovate/') && format('["{0}"]', vars.GH_RUNNER_RENOVATE || 'ubuntu-latest') || (inputs.runner-mode || vars.GH_RUNNER_MODE) == 'free' && '["ubuntu-latest"]' || inputs.test-matrix || format('["{0}"]', inputs.runner-test || vars.GH_RUNNER_RUST || vars.GH_RUNNER_DEFAULT || 'ubuntu-latest')) }}
+        os: ${{ fromJson(startsWith(github.head_ref || github.ref_name, 'renovate/') && format('["{0}"]', vars.GH_RUNNER_RENOVATE_RUST || vars.GH_RUNNER_RUST || 'ubuntu-latest') || (inputs.runner-mode || vars.GH_RUNNER_MODE) == 'free' && '["ubuntu-latest"]' || inputs.test-matrix || format('["{0}"]', inputs.runner-test || vars.GH_RUNNER_RUST || vars.GH_RUNNER_DEFAULT || 'ubuntu-latest')) }}
     steps:
       - name: Docker Hub login
         if: ${{ vars.DOCKERHUB_USERNAME != '' }}

--- a/.github/workflows/ts-ci.yml
+++ b/.github/workflows/ts-ci.yml
@@ -225,13 +225,13 @@ jobs:
           ref: ${{ inputs.tag || github.ref }}
 
       - name: Set up Node.js
-        if: ${{ !contains(runner.name, 'arc-runner') }}
+        if: ${{ runner.environment != 'self-hosted' }}
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ inputs.node-version }}
 
       - name: Install uv
-        if: ${{ !contains(runner.name, 'arc-runner') }}
+        if: ${{ runner.environment != 'self-hosted' }}
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           enable-cache: false
@@ -287,13 +287,13 @@ jobs:
           ref: ${{ inputs.tag || github.ref }}
 
       - name: Set up Node.js
-        if: ${{ !contains(runner.name, 'arc-runner') }}
+        if: ${{ runner.environment != 'self-hosted' }}
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ inputs.node-version }}
 
       - name: Install uv
-        if: ${{ !contains(runner.name, 'arc-runner') }}
+        if: ${{ runner.environment != 'self-hosted' }}
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           enable-cache: false
@@ -368,13 +368,13 @@ jobs:
           fi
 
       - name: Set up Node.js
-        if: ${{ !contains(runner.name, 'arc-runner') }}
+        if: ${{ runner.environment != 'self-hosted' }}
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ inputs.node-version }}
 
       - name: Install uv
-        if: ${{ !contains(runner.name, 'arc-runner') }}
+        if: ${{ runner.environment != 'self-hosted' }}
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           enable-cache: false

--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ No code changes, no workflow changes.
 | `hyperi-ci watch [--timeout SEC]` | Watch latest CI run (default 3600s; `--timeout 0` disables) |
 | `hyperi-ci logs [--failed]` | Show CI run logs |
 | `hyperi-ci init` | Scaffold a new project |
-| `hyperi-ci upgrade` | Upgrade to the channel's release (see `autoupdate`) |
+| `hyperi-ci update` | Update to the channel's release (see `autoupdate`) |
 | `hyperi-ci autoupdate [status\|channel live\|stable\|freeze\|unfreeze]` | Show/set how the CLI updates itself |
 
 `hyperi-ci release` is kept as a deprecated alias of `hyperi-ci publish`

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -226,7 +226,7 @@ hyperi-ci detect | config          show detected language / merged config
 hyperi-ci trigger | watch | logs   drive GitHub Actions from the terminal
 hyperi-ci install-toolchains | install-native-deps | install-deps   runner/CI dep install
 hyperi-ci init-contract | emit-artefacts | overlay-render | stitch | init-gitops | init-topology   deployment artefacts
-hyperi-ci upgrade                  self-upgrade the installed tool
+hyperi-ci update                  self-upgrade the installed tool
 hyperi-ci autoupdate               channel (live|stable) / enable / freeze -- see self-update.md
 ```
 

--- a/docs/deployment/tiers.md
+++ b/docs/deployment/tiers.md
@@ -219,7 +219,7 @@ into an invalid state.
 
 **"contract declares schema_version=N but this hyperi-ci supports up to M"**
 Your contract was emitted by a newer producer than this hyperi-ci.
-Run `hyperi-ci upgrade` (or `uv tool install --force --refresh hyperi-ci@latest`)
+Run `hyperi-ci update` (or `uv tool install --force --refresh hyperi-ci@latest`)
 and retry. Prefer either of those over `uv tool upgrade`, which silently declines
 on an install pinned to an exact version.
 

--- a/docs/self-update.md
+++ b/docs/self-update.md
@@ -20,8 +20,8 @@ hyperi-ci autoupdate channel stable       # opt into the soak window
 hyperi-ci autoupdate disable              # stop auto-update, keep the channel
 hyperi-ci autoupdate freeze               # kill-switch: nothing updates
 hyperi-ci autoupdate unfreeze
-hyperi-ci upgrade                         # upgrade now, to the channel's release
-hyperi-ci upgrade 2.9.4                   # install exactly this (see below)
+hyperi-ci update                         # upgrade now, to the channel's release
+hyperi-ci update 2.9.4                   # install exactly this (see below)
 ```
 
 ## It is a package, not a clone
@@ -52,7 +52,7 @@ used, leaving no pin behind.
 
 Switching to `stable` while already ahead of the soak window does **not** roll
 the install back. The channel holds the version still; it never downgrades. Only
-an explicit `hyperi-ci upgrade <version>` installs something older.
+an explicit `hyperi-ci update <version>` installs something older.
 
 ## Where the state lives
 
@@ -98,7 +98,7 @@ for a workstation.
 
 ## An explicit version is not a pin
 
-`hyperi-ci upgrade 2.9.4` installs 2.9.4 and warns, because auto-update clears
+`hyperi-ci update 2.9.4` installs 2.9.4 and warns, because auto-update clears
 the receipt pin it leaves and moves back to the channel target within 4 hours.
 To hold a version, hold auto-update: `hyperi-ci autoupdate freeze`.
 
@@ -119,7 +119,7 @@ quiet for four hours at a time.
 saw it. Both uv paths carry `--refresh`. pip has no index-only refresh, so it is
 left alone and the post-check reports stale metadata instead.
 
-`hyperi-ci upgrade` deliberately does not re-exec. It has no original command to
+`hyperi-ci update` deliberately does not re-exec. It has no original command to
 carry on with, and re-exec'ing meant running `upgrade` again in the new binary --
 which, in a binary old enough to trust a zero exit code, re-execs on every
 "Nothing to upgrade" and never terminates.

--- a/src/hyperi_ci/cli.py
+++ b/src/hyperi_ci/cli.py
@@ -17,7 +17,7 @@ Usage:
     hyperi-ci watch [RUN_ID]            Watch a GitHub Actions run to completion
     hyperi-ci logs [RUN_ID]             Fetch and filter GitHub Actions run logs
     hyperi-ci release <tag>             Trigger publish for a version tag
-    hyperi-ci upgrade                   Upgrade to the channel's release
+    hyperi-ci update                    Update to the channel's release
     hyperi-ci autoupdate                Show/set self-update channel + freeze
     hyperi-ci check-commit              Validate commit message format
     hyperi-ci stitch <topology-dir>     Stitch a DeploymentTopology into an umbrella Helm chart
@@ -1445,6 +1445,29 @@ def tag_head_cmd(
 
 
 @app.command()
+def update(
+    target_version: Annotated[
+        str | None,
+        typer.Argument(help="Specific version to install (default: latest)"),
+    ] = None,
+    pre: Annotated[
+        bool,
+        typer.Option("--pre", help="Include pre-releases when resolving latest"),
+    ] = False,
+) -> None:
+    """Update hyperi-ci to its channel's release (or a specific version).
+
+    Which release "latest" means is the channel's decision: `live` (the
+    default) takes the newest release on PyPI, `stable` takes the newest one
+    that has soaked for 7 days. See `hyperi-ci autoupdate`.
+    """
+    from hyperi_ci.upgrade import run_upgrade
+
+    rc = run_upgrade(version=target_version, pre=pre)
+    raise typer.Exit(rc)
+
+
+@app.command(hidden=True)
 def upgrade(
     target_version: Annotated[
         str | None,
@@ -1455,16 +1478,16 @@ def upgrade(
         typer.Option("--pre", help="Include pre-releases when resolving latest"),
     ] = False,
 ) -> None:
-    """Upgrade hyperi-ci to its channel's release (or a specific version).
+    """Update hyperi-ci -- the deprecated spelling of `update`.
 
-    Which release "latest" means is the channel's decision: `live` (the
-    default) takes the newest release on PyPI, `stable` takes the newest one
-    that has soaked for 7 days. See `hyperi-ci autoupdate`.
+    The verb is `update` across the toolchain (`hyperi-ai update`). This
+    spelling keeps working because it is in docs and CI images; removal is a
+    4.0 change.
     """
-    from hyperi_ci.upgrade import run_upgrade
+    from hyperi_ci.common import warn
 
-    rc = run_upgrade(version=target_version, pre=pre)
-    raise typer.Exit(rc)
+    warn("`hyperi-ci upgrade` is deprecated -- use `hyperi-ci update`.")
+    update(target_version=target_version, pre=pre)
 
 
 @app.command()

--- a/src/hyperi_ci/native_deps.py
+++ b/src/hyperi_ci/native_deps.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import os
 import platform
+import shutil
 import subprocess
 import sys
 import urllib.error
@@ -644,9 +645,6 @@ def _install_language_tools(language: str) -> int:
     if platform.system() != "Linux":
         return 0
 
-    import os
-    import shutil
-
     for tool in tools:
         # Ensure the tool's install dir is on PATH before probe + install
         bin_dir = Path.home() / tool.bin_dir
@@ -659,6 +657,17 @@ def _install_language_tools(language: str) -> int:
             continue
 
         cmd = [*tool.installer, *tool.args]
+
+        # A missing installer raises FileNotFoundError before the process
+        # starts, which `check=False` does not cover (issue #91). Rust reaches
+        # here before `Install Rust toolchain` runs, so cargo may not exist.
+        if shutil.which(cmd[0]) is None:
+            logger.warning(
+                f"[{tool.name}] {cmd[0]} not on PATH — skipping; dependent CI "
+                "stages will handle the missing tool"
+            )
+            continue
+
         logger.info(f"Installing {tool.name}: {' '.join(cmd)}")
         result = subprocess.run(cmd, check=False)
         if result.returncode != 0:

--- a/src/hyperi_ci/upgrade.py
+++ b/src/hyperi_ci/upgrade.py
@@ -581,7 +581,7 @@ def _refuse_when_frozen() -> bool:
 
 
 def _explicit_target(pre: bool) -> UpgradeTarget | None:
-    """Resolve the target for an unpinned ``hyperi-ci upgrade``.
+    """Resolve the target for an unpinned ``hyperi-ci update``.
 
     Args:
         pre: Include pre-releases when resolving.
@@ -681,7 +681,7 @@ def run_upgrade(
         )
 
     logger.info(f"{PACKAGE} upgraded: {current} -> {target}")
-    # No re-exec here. `hyperi-ci upgrade` has no original command to carry on
+    # No re-exec here. `hyperi-ci update` has no original command to carry on
     # with, so re-exec'ing means running `upgrade` again in the new binary --
     # and a new binary old enough to trust a zero exit code (before #82) then
     # re-execs on every "Nothing to upgrade", which never terminates.

--- a/tests/unit/test_native_deps.py
+++ b/tests/unit/test_native_deps.py
@@ -731,3 +731,51 @@ class TestAllModeBypass:
         )
         assert rc == 0
         assert installed_packages == []
+
+
+class TestLanguageToolInstallerAbsent:
+    """issue #91: a missing installer degrades, it does not crash.
+
+    `install_language_tools` documents itself as non-fatal, but
+    `subprocess.run(..., check=False)` only suppresses a non-zero EXIT --
+    a missing executable raises FileNotFoundError before the process starts.
+    Rust reaches this before the workflow installs rustup.
+    """
+
+    def test_missing_installer_binary_warns_and_continues(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(native_deps.platform, "system", lambda: "Linux")
+        # cargo absent, and the tool it would install is absent too.
+        monkeypatch.setattr(native_deps.shutil, "which", lambda _cmd: None)
+
+        def explode(*_args: object, **_kwargs: object) -> None:
+            raise AssertionError("must not invoke a missing installer")
+
+        monkeypatch.setattr(native_deps.subprocess, "run", explode)
+
+        assert native_deps._install_language_tools("rust") == 0
+
+    def test_present_installer_is_still_invoked(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The skip stays narrow -- a real cargo still installs the tool."""
+        monkeypatch.setattr(native_deps.platform, "system", lambda: "Linux")
+        monkeypatch.setattr(
+            native_deps.shutil,
+            "which",
+            lambda cmd: "/usr/bin/cargo" if cmd == "cargo" else None,
+        )
+        calls: list[list[str]] = []
+
+        def fake_run(cmd: list[str], **_kwargs: object) -> subprocess.CompletedProcess:
+            calls.append(cmd)
+            return subprocess.CompletedProcess(cmd, 0)
+
+        monkeypatch.setattr(native_deps.subprocess, "run", fake_run)
+
+        assert native_deps._install_language_tools("rust") == 0
+        assert calls, "a present cargo must still be invoked"
+        assert calls[0][0] == "cargo"

--- a/tests/unit/test_workflow_consistency.py
+++ b/tests/unit/test_workflow_consistency.py
@@ -623,6 +623,32 @@ def test_release_tail_uses_shared_workflow(workflow_name: str) -> None:
     )
 
 
+def test_rust_renovate_carveout_never_lands_on_a_toolchainless_runner() -> None:
+    """issue #91: renovate/ branches must resolve to a runner with cargo.
+
+    GH_RUNNER_RENOVATE and GH_RUNNER_DEFAULT point at vanilla sets, and Rust
+    does not bootstrap its toolchain at job time — so rust-ci.yml's renovate
+    carve-out must chain GH_RUNNER_RENOVATE_RUST -> GH_RUNNER_RUST, never the
+    shared GH_RUNNER_RENOVATE.
+    """
+    import re
+
+    text = (WORKFLOW_DIR / "rust-ci.yml").read_text(encoding="utf-8")
+    expressions = [
+        line for line in text.splitlines() if "renovate/" in line and "${{" in line
+    ]
+    assert expressions, "rust-ci.yml: the renovate carve-out has vanished entirely"
+    for line in expressions:
+        assert not re.search(r"GH_RUNNER_RENOVATE(?!_RUST)", line), (
+            f"rust-ci.yml routes a renovate/ branch through the shared "
+            f"GH_RUNNER_RENOVATE (a vanilla set with no cargo): {line.strip()}"
+        )
+        assert "GH_RUNNER_RUST" in line, (
+            f"rust-ci.yml renovate carve-out must fall back to GH_RUNNER_RUST: "
+            f"{line.strip()}"
+        )
+
+
 # Steps in _release-tail.yml that PUSH to the default branch or create a tag.
 # Named by the `name:` field so a reordering does not silently drop one.
 _PUSHING_STEPS = (


### PR DESCRIPTION
Closes #94.

The issue offers three options — widen the match to `arc-`, pin `version:`, or
probe with `command -v uv`. There is a fourth that is better than all of them:
GitHub already exposes the property the guard actually wanted.

`runner.environment` is `self-hosted` or `github-hosted`, and the docs confirm
the `runner` context is available in a step-level `if:`. So the guard becomes:

```yaml
if: ${{ runner.environment != 'self-hosted' }}
```

That states the intent instead of encoding a naming convention, so the next
rename cannot break it — which is the actual failure mode here, twice over
(this, and the repo runner vars in #91).

Applied to all 22 sites across `setup-runtime/action.yml` and the four
language workflows. Verified none of them used the non-negated form first, so
there is no mixed semantics to preserve.

## Bonus: the same guard, same rot

`rust-ci.yml` gates `Install Rust toolchain` and `Cache cargo` on the same
broken condition. Since the rename they have been running on native runners
too, redundantly installing rustup over the baked estate and restoring a cache
the image already has. Fixed by the same change — I flagged this in #93 as
adjacent rot, and it turns out to be the same line.

## Not done, deliberately

Pinning setup-uv's `version:` input. `config/versions.yaml` tracks the ACTION
version (`setup-uv: v9.0.0`), not the uv tool version, so pinning needs a new
tracked value plus Renovate wiring — a bigger change than a one-liner and a
separate concern.

With the guard correct, ARC skips `setup-uv` entirely, so the manifest fetch
that failed the promotion gate cannot happen there at all. It could still
occur on a hosted runner; if that ever bites, the pin is the follow-up.

## Verified

1891 tests pass. The change is mechanical and identical at every site.

NOT verified: a live ARC run confirming setup-uv is skipped. Workflows float
`@main`, so merging is the rollout — the done-when check is the next canary
run showing no `Install uv` step on an `arc-*` runner.
