### PR TITLE
fix(release): a shipped container that fails must not cut a tag

### DIFF
--- a/.github/workflows/_release-tail.yml
+++ b/.github/workflows/_release-tail.yml
@@ -117,6 +117,10 @@ jobs:
     permissions:
       contents: read
       packages: write
+    outputs:
+      # Whether this project ships a container at all, so tag-and-publish can
+      # tell "the deliverable failed" from "there was never a container".
+      ships-container: ${{ steps.resolve.outputs.build }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -206,16 +210,27 @@ jobs:
   tag-and-publish:
     name: Tag & Publish
     needs: [container]
-    # Runs iff a release is being published — and DECOUPLED from the
-    # container outcome (issue #33). `always()` means a failed or skipped
-    # Container job does not block the primary publish: a transient
-    # container/registry hiccup (e.g. a flaky Docker Hub buildkit pull)
-    # must never lose the crate/PyPI/npm + GitHub Release or skip the tag.
-    # The container failure still surfaces as a red run for follow-up.
+    # Runs iff a release is being published, and is DECOUPLED from the
+    # container outcome (issue #33) for projects that do not ship a
+    # container: a transient container/registry hiccup must never lose the
+    # crate/PyPI/npm + GitHub Release or skip the tag.
+    #
+    # For a project that DOES ship a container the container IS the
+    # deliverable, so the same decoupling published a lie: dfe-loader
+    # v1.18.19 cut its tag and GitHub Release while a Docker Hub 502 failed
+    # the build, leaving `latest` advertising a version GHCR never had, and
+    # anything pinning from the release page got an image that did not exist
+    # (issue #102). Those projects skip the crate registry anyway (a binary
+    # application has no crate to publish), so blocking here loses nothing
+    # that #33 set out to protect.
+    #
     # On push events this creates the git tag (semantic-release) AND
     # uploads artefacts. On workflow_dispatch (retroactive) the tag
     # already exists; only the upload runs.
-    if: ${{ always() && inputs.will-publish == 'true' }}
+    if: >-
+      ${{ always() && inputs.will-publish == 'true'
+          && (needs.container.result == 'success'
+              || needs.container.outputs.ships-container != 'true') }}
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/tests/unit/test_workflow_consistency.py
+++ b/tests/unit/test_workflow_consistency.py
@@ -151,6 +151,24 @@ class TestFromHeadThreading:
         wc = on.get("workflow_call", {}).get("inputs", {})
         assert "from-head" in wc and "bump" in wc
 
+    def test_release_tail_blocks_the_tag_when_a_shipped_container_fails(self) -> None:
+        # A container-shipping project must not cut a tag/release its image
+        # does not back (issue #102): dfe-loader v1.18.19 advertised a version
+        # GHCR never had. A library keeps the issue-#33 decoupling.
+        wf = _load_workflow("_release-tail.yml")
+        container = wf["jobs"]["container"]
+        assert container.get("outputs", {}).get("ships-container"), (
+            "container job must expose ships-container so tag-and-publish can "
+            "tell a failed deliverable from a project that ships no container"
+        )
+        ifc = " ".join(str(wf["jobs"]["tag-and-publish"]["if"]).split())
+        assert "needs.container.result == 'success'" in ifc, (
+            "tag-and-publish must require a successful container..."
+        )
+        assert "needs.container.outputs.ships-container != 'true'" in ifc, (
+            "...unless the project ships no container (issue #33 decoupling)"
+        )
+
     def test_release_tail_tags_head_on_dispatch_auto(self) -> None:
         # semantic-release tags HEAD on from-head + bump=auto (re-uses the
         # push tagger). Forced bumps use tag-head instead.


### PR DESCRIPTION
Closes the imageless-release hole from #102, live-hit on dfe-loader v1.18.19: Container failed on a Docker Hub 502 while Tag & Publish succeeded, so the release page advertised a version GHCR never had. Anything pinning from that release gets an image that was never pushed, and it lands as ImagePullBackOff.

**Not a revert of #33.** That decoupling exists so a registry blip never loses a crates.io/PyPI/npm publish, and it stays exactly as-is for libraries. It only misfires where the container IS the deliverable.

The lever turned out to be one you already compute. The container job's `Resolve container build (app vs library)` step decides whether the project ships a container at all; it is now a job output, so `tag-and-publish` can distinguish "the deliverable failed" from "there was never a container":

- ships a container + container did not succeed -> no tag, no release
- ships no container -> today's `always()` path, untouched

Container-shipping projects lose nothing by blocking, because a binary application already skips the crate registry (`rust/publish.py` returns early on `_detect_binary_names()`), so there is no language publish here for #33 to protect.

Unit suite 2016 passed, 1 skipped. The new consistency test was proven to fail when the gate is stripped, not just to pass with it.

**Two deliberate omissions from the original proposal, both yours to call:**

- **Buildx retry.** The Docker Hub pull that 502'd has no retry, so one blip still burns the container job -- now visibly, rather than silently shipping a bad release. Fixing it properly means adding a third-party retry action to every repo's release path, which is a supply-chain decision I am not making unilaterally. Happy to add it on your word.
- **Prerelease marking as a fallback.** With the gate in place a container-shipping repo cannot reach the release step on a failed container, so the marking has nothing left to catch. Worth adding only if you want defence in depth for a path I have not thought of.

Consumer-side backstop already landed in dfe-infra (`scripts/check_image_pins.py`): it verifies every pinned version exists in the registry AND that its digest matches, so a bad pin cannot enter that repo even from an upstream that misbehaves.
