### PR TITLE
fix(release): drive the changelog-preset pin from versions.yaml

### DIFF
--- a/.github/actions/setup-semantic-release/action.yml
+++ b/.github/actions/setup-semantic-release/action.yml
@@ -44,6 +44,8 @@ runs:
 
     - name: Install semantic-release + plugins (pinned)
       shell: bash
+      # Every version literal below is driven from config/versions.yaml by
+      # scripts/update-versions.py -- edit it there, not here.
       run: |
         npm install -g \
           semantic-release@25 \
@@ -53,7 +55,7 @@ runs:
           @semantic-release/exec \
           @semantic-release/git \
           @semantic-release/github \
-          conventional-changelog-conventionalcommits
+          conventional-changelog-conventionalcommits@9
 
     - name: Provide the release config (central default, never the #37 plugins)
       shell: bash

--- a/scripts/update-versions.py
+++ b/scripts/update-versions.py
@@ -514,6 +514,13 @@ def _build_replacements(versions: dict) -> list[tuple[re.Pattern, str, str]]:
         replacement = rf"\g<1>{sr_core}"
         replacements.append((pattern, replacement, f"semantic-release@{sr_core}"))
 
+    # Plugin majors, driven from the SSOT exactly as `core` is, so a pin in the
+    # install line cannot drift from the value recorded here.
+    for pkg, major in (sr.get("plugin_majors") or {}).items():
+        pattern = re.compile(rf"(?<![\w-])({re.escape(pkg)}@)\S+")
+        replacement = rf"\g<1>{major}"
+        replacements.append((pattern, replacement, f"{pkg}@{major}"))
+
     return replacements
 
 

--- a/src/hyperi_ci/config/versions.yaml
+++ b/src/hyperi_ci/config/versions.yaml
@@ -254,3 +254,10 @@ semantic_release:
     - "@semantic-release/git"
     - "@semantic-release/github"
     - "conventional-changelog-conventionalcommits"
+  # Plugins whose MAJOR is pinned in the install line, driven from here the same
+  # way `core` is. A plugin listed above but absent here floats to latest.
+  plugin_majors:
+    # v10 requires conventional-changelog-writer@9, which core 25 does not
+    # bring; unpinned, v10 broke the dry-run in every repo at once. Lifting this
+    # means moving `core` with it.
+    conventional-changelog-conventionalcommits: "9"

--- a/tests/unit/test_update_versions.py
+++ b/tests/unit/test_update_versions.py
@@ -44,6 +44,66 @@ class TestSemanticReleasePin:
         assert out == ref
 
 
+class TestSemanticReleasePluginMajors:
+    """A plugin pin in the install line must be driven from the SSOT.
+
+    An unpinned plugin takes whatever npm serves that morning:
+    conventional-changelog-conventionalcommits v10 landed needing
+    conventional-changelog-writer@9, which core 25 does not bring, and the
+    dry-run broke in every repo at once. A pin fixes that only if the SSOT
+    owns the number -- a literal typed into the action drifts silently.
+    """
+
+    VERSIONS = {
+        "semantic_release": {
+            "core": "25",
+            "plugin_majors": {"conventional-changelog-conventionalcommits": "9"},
+        }
+    }
+
+    def test_pins_the_plugin_major(self) -> None:
+        out = _apply("  conventional-changelog-conventionalcommits@7", self.VERSIONS)
+        assert "conventional-changelog-conventionalcommits@9" in out
+
+    def test_rewrites_a_drifted_pin_back_to_the_ssot(self) -> None:
+        out = _apply("  conventional-changelog-conventionalcommits@10", self.VERSIONS)
+        assert "conventional-changelog-conventionalcommits@9" in out
+        assert "@10" not in out
+
+    def test_leaves_an_unlisted_plugin_alone(self) -> None:
+        line = "  @semantic-release/changelog"
+        assert _apply(line, self.VERSIONS) == line
+
+    def test_absent_plugin_majors_is_not_an_error(self) -> None:
+        line = "  conventional-changelog-conventionalcommits@9"
+        assert _apply(line, {"semantic_release": {"core": "25"}}) == line
+
+    def test_the_shipped_action_matches_the_shipped_ssot(self) -> None:
+        """The real files, so a hand-edited pin fails here rather than in CI."""
+        import yaml
+
+        root = Path(__file__).resolve().parents[2]
+        versions = yaml.safe_load(
+            (root / "src" / "hyperi_ci" / "config" / "versions.yaml").read_text(
+                encoding="utf-8", errors="replace"
+            )
+        )
+        action = (
+            root / ".github" / "actions" / "setup-semantic-release" / "action.yml"
+        ).read_text(encoding="utf-8", errors="replace")
+
+        majors = versions["semantic_release"].get("plugin_majors") or {}
+        assert majors, "the SSOT records no plugin pins; this guard would test nothing"
+        for pkg, major in majors.items():
+            assert f"{pkg}@{major}" in action, (
+                f"{pkg} is pinned to {major} in versions.yaml but the action "
+                f"install line disagrees"
+            )
+        assert _apply(action, versions) == action, (
+            "applying the SSOT replacements changed the action -- it has drifted"
+        )
+
+
 def _sha_versions(sha: str = "abc123", version: str = "v6.0.2") -> dict:
     return {"actions": {"checkout": {"version": version, "sha": sha}}}
 


### PR DESCRIPTION
Every repo in the estate lost the ability to release yesterday.
`conventional-changelog-conventionalcommits` v10.4.0 published 2026-08-18 and
needs `conventional-changelog-writer@9`, which semantic-release 25 does not
bring, so the Plan job's dry-run dies with `Missing helper`.

The install step is labelled "(pinned)" and pinned one of its eight packages.
The preset floated, npm served v10, and every repo broke at once.

Pinned to major 9 -- the major this pipeline resolved on 2026-08-03, when the
last green release went out.

**The pin is driven from versions.yaml, not typed into the action.** A literal
in the workflow is the version-hack spiral the SSOT exists to prevent: it drifts
from the recorded value and nothing notices. So `semantic_release` gains a
`plugin_majors` map, `_build_replacements` emits a rule for it exactly as it
already does for `core`, and `update-versions.py --check` enforces that the
install line and the SSOT agree. A plugin listed under `plugins` but absent from
`plugin_majors` still floats, which is the existing behaviour for the seven that
are fine.

Five tests, including one that reads the SHIPPED action and the SHIPPED
versions.yaml and fails if they disagree -- verified by planting an `@8` in the
action and watching it fail with the drifted package named.

## Verification

- `hyperi-ci check` green: 2125 passed, coverage 67.66%, and semgrep, gitleaks,
  pip-audit, vulture, ruff all clean.
- `scripts/update-versions.py --check` reports "All workflow files and tool pins
  match versions.yaml".

## Forward path

Lifting this pin means moving `core` with it, since v10 wants a newer writer
than semantic-release 25 carries. Filed separately rather than bundled here --
a core bump changes the tagger for 14 repos and wants its own soak.
