### PR TITLE
fix(release): refuse a versionless dispatch and honour python opt-out (#105)

### DIFF
--- a/.github/actions/predict-version/action.yml
+++ b/.github/actions/predict-version/action.yml
@@ -21,6 +21,10 @@ inputs:
   github-token:
     description: GitHub token (for semantic-release dry-run)
     required: true
+  tag:
+    description: "Tag to re-publish on a workflow_dispatch (retroactive). Empty on a from-head or push run."
+    required: false
+    default: ""
   from-head:
     description: "'true' on a from-head dispatch (issue #35): resolve version for tagging HEAD"
     required: false
@@ -62,6 +66,18 @@ runs:
       shell: bash
       run: |
         if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+          # A dispatch publishes in exactly one of two modes, each of which
+          # resolves a real version: `tag=vX.Y.Z` re-publishes an existing
+          # release (version = the tag), and `from-head=true` releases HEAD
+          # (the CI computes + cuts the tag). A BARE dispatch (neither) resolves
+          # no version, so every downstream consumer falls back to the committed
+          # manifest seed — how a four-month-old version was rebuilt from
+          # today's HEAD and clobbered `latest` on GHCR + R2 (issue #105).
+          # Refuse it HERE, before the container job can build and push it.
+          if [[ -z "${{ inputs.tag }}" && "${{ inputs.from-head }}" != "true" ]]; then
+            echo "::error::workflow_dispatch with neither 'tag' nor 'from-head: true' — refusing to publish (issue #105). A bare dispatch resolves no version and would name the release from the committed manifest. Re-run with from-head=true (bump=auto|patch|minor|X.Y.Z) to release HEAD, or set tag=vX.Y.Z to re-publish an existing release."
+            exit 1
+          fi
           echo "will-publish=true" >> "$GITHUB_OUTPUT"
           echo "::notice::Triggered by workflow_dispatch — publish run"
           exit 0

--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -160,6 +160,7 @@ jobs:
         uses: hyperi-io/hyperi-ci/.github/actions/predict-version@main
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ inputs.tag }}
           from-head: ${{ inputs.from-head }}
           bump: ${{ inputs.bump }}
           branch-build: ${{ inputs.branch-build || vars.HYPERCI_BRANCH_BUILD }}

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -161,6 +161,7 @@ jobs:
         uses: hyperi-io/hyperi-ci/.github/actions/predict-version@main
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ inputs.tag }}
           from-head: ${{ inputs.from-head }}
           bump: ${{ inputs.bump }}
           branch-build: ${{ inputs.branch-build || vars.HYPERCI_BRANCH_BUILD }}

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -177,6 +177,7 @@ jobs:
         uses: hyperi-io/hyperi-ci/.github/actions/predict-version@main
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ inputs.tag }}
           from-head: ${{ inputs.from-head }}
           bump: ${{ inputs.bump }}
           branch-build: ${{ inputs.branch-build || vars.HYPERCI_BRANCH_BUILD }}

--- a/.github/workflows/ts-ci.yml
+++ b/.github/workflows/ts-ci.yml
@@ -158,6 +158,7 @@ jobs:
         uses: hyperi-io/hyperi-ci/.github/actions/predict-version@main
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ inputs.tag }}
           from-head: ${{ inputs.from-head }}
           bump: ${{ inputs.bump }}
           branch-build: ${{ inputs.branch-build || vars.HYPERCI_BRANCH_BUILD }}

--- a/src/hyperi_ci/publish/binaries.py
+++ b/src/hyperi_ci/publish/binaries.py
@@ -69,17 +69,68 @@ def _read_version() -> str | None:
     return resolve_release_version()
 
 
-def _collect_artifacts() -> list[Path]:
+_PYTHON_DIST_SUFFIXES = (".whl", ".tar.gz", ".zip")
+
+
+def _is_python_dist_artifact(path: Path) -> bool:
+    """True for a Python packaging artefact (wheel or sdist).
+
+    Used to honour ``destinations_oss.python: false``: a project that ships
+    no Python distribution must not leak its wheel/sdist to R2 or a GitHub
+    Release through the GENERIC binary publisher either (issue #105 BUG 2 —
+    the opt-out was previously honoured only by the python publish handler).
+    A ``.whl`` is unambiguously a wheel; the accompanying sdist (``.tar.gz`` /
+    ``.zip``) is dropped alongside it. Only ever consulted when the python
+    destination is opted out, so a Rust/Go tarball is never at risk.
+    """
+    name = path.name.lower()
+    return any(name.endswith(suffix) for suffix in _PYTHON_DIST_SUFFIXES)
+
+
+def _release_targets_head(tag: str) -> bool:
+    """True iff the git tag for an existing release points at HEAD.
+
+    An existing release AT HEAD is an idempotent re-run (safe to proceed);
+    one at a DIFFERENT commit means a stale version was resolved, and
+    re-publishing would overwrite a shipped release with different contents
+    (issue #105 — a four-month-old tag rebuilt from today's HEAD clobbered
+    ``latest``). When the tag cannot be resolved locally we cannot prove it
+    is HEAD, so we treat it as a mismatch and refuse.
+    """
+    tag_commit = run_cmd(
+        ["git", "rev-parse", "-q", "--verify", f"refs/tags/{tag}^{{commit}}"],
+        capture=True,
+        check=False,
+    )
+    if tag_commit.returncode != 0 or not tag_commit.stdout.strip():
+        return False
+    head_commit = run_cmd(
+        ["git", "rev-parse", "HEAD^{commit}"],
+        capture=True,
+        check=False,
+    )
+    if head_commit.returncode != 0 or not head_commit.stdout.strip():
+        return False
+    return tag_commit.stdout.strip() == head_commit.stdout.strip()
+
+
+def _collect_artifacts(exclude_python: bool = False) -> list[Path]:
     """Collect publishable artifacts from dist/ directory.
 
-    Returns sorted list of files, excluding hidden files.
+    Returns sorted list of files, excluding hidden files. When
+    ``exclude_python`` is set (the project opted out of a Python
+    distribution), Python packaging artefacts (wheels + sdists) are dropped
+    so they are never uploaded as generic binaries (issue #105 BUG 2).
     """
     dist = Path("dist")
     if not dist.is_dir():
         return []
-    return [
+    files = [
         f for f in sorted(dist.iterdir()) if f.is_file() and not f.name.startswith(".")
     ]
+    if exclude_python:
+        files = [f for f in files if not _is_python_dist_artifact(f)]
+    return files
 
 
 def create_github_release(config: CIConfig) -> int:
@@ -108,8 +159,22 @@ def create_github_release(config: CIConfig) -> int:
     result = run_cmd(cmd, check=False, capture=True)
     if result.returncode != 0:
         if "already exists" in result.stderr:
-            info(f"  GH Release {tag} already exists")
-            return 0
+            # A release for this tag already exists. Allow an idempotent
+            # re-run (same commit), but REFUSE to publish onto a release that
+            # points at a different commit — logging "already exists" and
+            # carrying on is how a stale-version dispatch overwrote `latest`
+            # (issue #105). The git tag is the source of truth for what commit
+            # the release shipped from.
+            if _release_targets_head(tag):
+                info(f"  GH Release {tag} already exists at HEAD — idempotent re-run")
+                return 0
+            error(
+                f"GH Release {tag} already exists at a commit other than HEAD — "
+                f"refusing to overwrite a shipped release (issue #105). A bare "
+                f"dispatch or a stale manifest seed resolved an old version; ship "
+                f"a new version instead of re-publishing {tag}."
+            )
+            return 1
         error("GitHub Release creation failed")
         if result.stderr:
             error(result.stderr)
@@ -119,18 +184,21 @@ def create_github_release(config: CIConfig) -> int:
     return 0
 
 
-def _upload_binaries_github(channel: str = "release") -> int:
+def _upload_binaries_github(
+    channel: str = "release", exclude_python: bool = False
+) -> int:
     """Create GitHub Release and upload built binaries.
 
     Creates a GH Release for the tag (from VERSION file). For non-release
     channels (spike, alpha, beta), the release is marked as prerelease.
-    Falls back to upload if the release already exists (idempotent re-runs).
+    Falls back to upload if the release already exists at HEAD (idempotent
+    re-runs); refuses to clobber a release at a different commit (#105).
 
     Returns:
         Exit code (0 = success).
 
     """
-    artifacts = _collect_artifacts()
+    artifacts = _collect_artifacts(exclude_python=exclude_python)
     if not artifacts:
         warn("No artifacts found in dist/ — skipping GitHub Release upload")
         return 0
@@ -150,7 +218,15 @@ def _upload_binaries_github(channel: str = "release") -> int:
     result = run_cmd(cmd, check=False, capture=True)
     if result.returncode != 0:
         if "already exists" in result.stderr:
-            info(f"  GH Release {tag} already exists — uploading artifacts")
+            # Only clobber a release that ships from HEAD (idempotent re-run);
+            # a different commit means a stale version resolved (issue #105).
+            if not _release_targets_head(tag):
+                error(
+                    f"GH Release {tag} already exists at a commit other than "
+                    f"HEAD — refusing to clobber its assets (issue #105)."
+                )
+                return 1
+            info(f"  GH Release {tag} already exists at HEAD — uploading artifacts")
             upload_cmd = ["gh", "release", "upload", tag, "--clobber"]
             upload_cmd.extend(str(f) for f in artifacts)
             result = subprocess.run(upload_cmd)
@@ -167,7 +243,7 @@ def _upload_binaries_github(channel: str = "release") -> int:
     return 0
 
 
-def _publish_r2_binaries(channel: str = "release") -> int:
+def _publish_r2_binaries(channel: str = "release", exclude_python: bool = False) -> int:
     """Publish built binaries to Cloudflare R2 binary repository.
 
     Uploads all files from dist/ to R2. Channel controls path:
@@ -194,7 +270,7 @@ def _publish_r2_binaries(channel: str = "release") -> int:
         error(missing_tool_notice("aws"))
         return 1
 
-    artifacts = _collect_artifacts()
+    artifacts = _collect_artifacts(exclude_python=exclude_python)
     if not artifacts:
         warn("No artifacts found in dist/ — skipping R2 binary publish")
         return 0
@@ -276,7 +352,13 @@ def publish_binaries(config: CIConfig) -> int:
     if not destinations:
         return 0
 
-    artifacts = _collect_artifacts()
+    # Honour destinations_oss.python: false for the generic binary publisher
+    # too — otherwise a private, container-only Python service still leaks its
+    # wheel + sdist to R2 on every run (issue #105 BUG 2). A Rust/Go project
+    # leaves python at its truthy default, so this never drops a real binary.
+    exclude_python = not config.destination_for("python")
+
+    artifacts = _collect_artifacts(exclude_python=exclude_python)
     if not artifacts:
         info("No dist/ artifacts — skipping binary publish")
         return 0
@@ -289,13 +371,17 @@ def publish_binaries(config: CIConfig) -> int:
     for dest in destinations:
         if dest == "github-releases":
             with group("Upload: GitHub Releases"):
-                rc = _upload_binaries_github(channel=channel)
+                rc = _upload_binaries_github(
+                    channel=channel, exclude_python=exclude_python
+                )
                 if rc != 0:
                     return rc
 
         elif dest == "r2-binaries":
             with group("Upload: Cloudflare R2"):
-                rc = _publish_r2_binaries(channel=channel)
+                rc = _publish_r2_binaries(
+                    channel=channel, exclude_python=exclude_python
+                )
                 if rc != 0:
                     return rc
 

--- a/tests/unit/test_publish.py
+++ b/tests/unit/test_publish.py
@@ -14,6 +14,7 @@ and is tested via integration tests against test projects.
 
 from __future__ import annotations
 
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -230,3 +231,100 @@ class TestCargoVersionSync:
         from hyperi_ci.languages.rust.publish import _sync_cargo_toml_version
 
         assert _sync_cargo_toml_version("1.0.0") is False
+
+
+class TestPythonDistExclusion:
+    """destinations_oss.python: false must also stop the wheel reaching R2
+    via the generic binary publisher (issue #105 BUG 2)."""
+
+    def test_wheel_and_sdist_are_python_artifacts(self) -> None:
+        from hyperi_ci.publish.binaries import _is_python_dist_artifact
+
+        assert _is_python_dist_artifact(Path("dfe_engine-1.17.0-py3-none-any.whl"))
+        assert _is_python_dist_artifact(Path("dfe_engine-1.17.0.tar.gz"))
+        assert _is_python_dist_artifact(Path("dfe_engine-1.17.0.zip"))
+
+    def test_binary_is_not_python_artifact(self) -> None:
+        from hyperi_ci.publish.binaries import _is_python_dist_artifact
+
+        assert not _is_python_dist_artifact(Path("dfe-receiver"))
+        assert not _is_python_dist_artifact(Path("dfe-receiver-x86_64-unknown-linux"))
+
+    def test_collect_excludes_python_when_flagged(self, tmp_path, monkeypatch) -> None:
+        monkeypatch.chdir(tmp_path)
+        dist = tmp_path / "dist"
+        dist.mkdir()
+        (dist / "dfe_engine-1.17.0-py3-none-any.whl").write_text("wheel")
+        (dist / "dfe_engine-1.17.0.tar.gz").write_text("sdist")
+        (dist / "dfe-receiver").write_text("binary")
+        from hyperi_ci.publish.binaries import _collect_artifacts
+
+        kept = {p.name for p in _collect_artifacts(exclude_python=True)}
+        assert kept == {"dfe-receiver"}
+        # Default (no exclusion) still sweeps in everything.
+        assert "dfe_engine-1.17.0-py3-none-any.whl" in {
+            p.name for p in _collect_artifacts()
+        }
+
+    def test_python_false_opts_out_but_keeps_binaries(self) -> None:
+        # The dfe-engine shape: python opted out, binaries still defaulted on.
+        config = CIConfig(
+            publish_target="oss",
+            _raw={
+                "publish": {
+                    "destinations_oss": {"python": False, "binaries": "r2-binaries"}
+                }
+            },
+        )
+        assert config.destination_for("python") == []
+        assert config.destination_for("binaries") == ["r2-binaries"]
+        # publish_binaries derives exclude_python from exactly this.
+        assert bool(config.destination_for("python")) is False
+
+
+class TestReleaseTargetsHead:
+    """Refuse to overwrite a release whose tag is not HEAD (issue #105)."""
+
+    @staticmethod
+    def _git(cwd: Path, *args: str) -> None:
+        subprocess.run(
+            ["git", "-c", "user.email=t@t", "-c", "user.name=t", *args],
+            cwd=cwd,
+            check=True,
+            capture_output=True,
+        )
+
+    def test_tag_at_head_is_true(self, tmp_path, monkeypatch) -> None:
+        self._git(tmp_path, "init")
+        (tmp_path / "f").write_text("a")
+        self._git(tmp_path, "add", "-A")
+        self._git(tmp_path, "commit", "-m", "one")
+        self._git(tmp_path, "tag", "v1.0.0")
+        monkeypatch.chdir(tmp_path)
+        from hyperi_ci.publish.binaries import _release_targets_head
+
+        assert _release_targets_head("v1.0.0") is True
+
+    def test_tag_off_head_is_false(self, tmp_path, monkeypatch) -> None:
+        self._git(tmp_path, "init")
+        (tmp_path / "f").write_text("a")
+        self._git(tmp_path, "add", "-A")
+        self._git(tmp_path, "commit", "-m", "one")
+        self._git(tmp_path, "tag", "v1.0.0")
+        (tmp_path / "f").write_text("b")
+        self._git(tmp_path, "add", "-A")
+        self._git(tmp_path, "commit", "-m", "two")
+        monkeypatch.chdir(tmp_path)
+        from hyperi_ci.publish.binaries import _release_targets_head
+
+        assert _release_targets_head("v1.0.0") is False
+
+    def test_missing_tag_is_false(self, tmp_path, monkeypatch) -> None:
+        self._git(tmp_path, "init")
+        (tmp_path / "f").write_text("a")
+        self._git(tmp_path, "add", "-A")
+        self._git(tmp_path, "commit", "-m", "one")
+        monkeypatch.chdir(tmp_path)
+        from hyperi_ci.publish.binaries import _release_targets_head
+
+        assert _release_targets_head("v9.9.9") is False


### PR DESCRIPTION
Closes #105.

A manual dispatch on dfe-engine rebuilt v1.8.0 (an April tag) from today's HEAD and took `latest` with it on GHCR and R2. Root cause: a bare `workflow_dispatch` (no `tag`, not `from-head`) still flipped `will-publish` on, but nothing computed a version, so every consumer fell back to the committed manifest seed (`pyproject.toml version = "1.8.0"`). No job failed, so nothing alerted.

Three fixes, root cause first:

- The gate now REFUSES a dispatch that is neither a `tag` re-publish nor a `from-head` release, and it does so in predict-version BEFORE the container job builds, so a versionless run cannot push anything. `tag` is threaded into predict-version from all four language workflows so a real tag re-publish still resolves its version and passes.
- The binary publisher stops swallowing "already exists" and carrying on. An existing GH Release is an idempotent re-run only when its tag points at HEAD; a release at a different commit is refused instead of `--clobber`ed. This is what actually overwrote `latest`, so it is guarded directly.
- `destinations_oss.python: false` now also excludes the wheel + sdist from the generic R2 binary publisher, not just the python handler. dfe-engine is container-only and should ship no python distribution anywhere.

Tests are real-filesystem + real-git, no mocks: python-artefact exclusion, and the tag-at-HEAD vs off-HEAD vs missing-tag cases. Full publish/config unit set green.

The reusable workflow is consumed `@main`, so this takes effect for every consumer the moment it lands -- which unblocks cutting dfe-engine v1.17.0 (the dashboards module) with the correct version.
