### PR TITLE
fix(gitleaks): report an unusable build as a tool fault, not a secret

### DIFF
--- a/src/hyperi_ci/quality/gitleaks.py
+++ b/src/hyperi_ci/quality/gitleaks.py
@@ -64,6 +64,44 @@ def _install_gitleaks() -> bool:
     )
 
 
+def _supports_git_subcommand() -> bool:
+    """Whether the gitleaks on PATH understands the `git` subcommand.
+
+    Probed rather than parsed from `gitleaks version`, which prints
+    "version is set by build process" on a distro build - no number to compare.
+    """
+    try:
+        probe = run_cmd(["gitleaks", "git", "--help"], check=False, capture=True)
+    except OSError:
+        return False
+    return probe.returncode == 0
+
+
+def _report_unusable(mode: str) -> int:
+    """Report a gitleaks that cannot run this scan, and never as a finding.
+
+    gitleaks exits non-zero for a usage error as well as for a leak, so the
+    exit code alone cannot tell "no scan ran" from "your repo has a secret".
+    Returns what the scan-failure path returns for this mode, so the outcome is
+    unchanged and only the reason differs.
+    """
+    notice = "\n".join(
+        (
+            "gitleaks: no scan ran - the installed build has no `git` "
+            "subcommand. This is a tool problem, not a finding.",
+            "  needed: 8.19.0 or newer, which replaced `detect` with `git`;"
+            f" hyperi-ci pins {tool_version('gitleaks')}.",
+            "  Ubuntu universe ships 8.16.0, below that floor.",
+            f"  {missing_tool_notice('gitleaks', head='`gitleaks` is installed but too old')}",
+        )
+    )
+    if mode == "warn":
+        warn(f"  {notice}")
+        return 0
+    error(f"  {notice}")
+    return 1
+
+
 def _find_config() -> str | None:
     """Find gitleaks config file in project."""
     for path in (".gitleaks.toml", "ci/.gitleaks.toml"):
@@ -203,6 +241,11 @@ def run(config: CIConfig) -> int:
         warn("  gitleaks: skipping secret scanning")
         warn(f"  {missing_tool_notice('gitleaks')}")
         return 0
+
+    # `_install_gitleaks` is satisfied by anything named gitleaks on PATH, so
+    # the build still has to be checked before the scan is built around `git`.
+    if not _supports_git_subcommand():
+        return _report_unusable(mode)
 
     # Scan git history. `git` supersedes the deprecated `detect` subcommand
     # (gone from --help as of 8.30.1, still honoured for back-compat); the repo

--- a/src/hyperi_ci/tools.py
+++ b/src/hyperi_ci/tools.py
@@ -177,22 +177,28 @@ def missing_tool_notice(
     purpose: str | None = None,
     install: tuple[str, ...] | list[str] | None = None,
     url: str | None = None,
+    head: str | None = None,
 ) -> str:
     """Render the actionable 'here is how to fix it' notice for a missing tool.
 
     Uses the registry as the default and lets a caller override any field
     (a one-off tool, or a context-specific purpose). Multi-line, safe to pass
     straight to :func:`info` / :func:`warn` / :func:`error`.
+
+    ``head`` replaces the "is not installed" opening for a tool that IS present
+    but unusable - an unsupported version, say. The install guidance is the same
+    either way, and this keeps a caller from restating it to avoid saying
+    something false.
     """
     reg = _REGISTRY.get(name)
     purpose = purpose if purpose is not None else (reg.purpose if reg else None)
     installs = tuple(install) if install is not None else (reg.install if reg else ())
     url = url if url is not None else (reg.url if reg else "")
 
-    head = f"`{name}` is not installed"
+    opening = head if head is not None else f"`{name}` is not installed"
     if purpose:
-        head += f" - hyperi-ci needs it for {purpose}"
-    lines = [head + "."]
+        opening += f" - hyperi-ci needs it for {purpose}"
+    lines = [opening + "."]
     if installs:
         lines.append("  help: install it with one of:")
         lines.extend(f"    {cmd}" for cmd in installs)

--- a/tests/unit/test_gitleaks.py
+++ b/tests/unit/test_gitleaks.py
@@ -76,6 +76,10 @@ def _fake_gitleaks(
         return subprocess.CompletedProcess(cmd, scan_rc, "", "")
 
     monkeypatch.setattr(gitleaks, "_install_gitleaks", lambda: True)
+    # Stubbed alongside the install check, and for the same reason: the probe
+    # shells out to `gitleaks git --help`, which would otherwise be recorded as
+    # the first gitleaks call and stand in for the scan in _scan_cmd.
+    monkeypatch.setattr(gitleaks, "_supports_git_subcommand", lambda: True)
     monkeypatch.setattr(gitleaks, "run_cmd", fake_run_cmd)
     monkeypatch.setattr(gitleaks.subprocess, "run", fake_run)
     return calls
@@ -250,6 +254,84 @@ class TestLeaksFound:
         monkeypatch.setenv("HYPERCI_QUALITY_STRICT", "1")
         cfg = _cfg({"quality": {"gitleaks": "warn"}})
         assert gitleaks.run(cfg) == 1
+
+
+class TestUnusableBuild:
+    """An installed gitleaks too old to run the scan is a TOOL fault.
+
+    Ubuntu universe ships 8.16.0, which predates the 8.19.0 split of `detect`
+    into `git`/`dir`/`stdin`. `_install_gitleaks` accepts anything called
+    gitleaks on PATH, so that build reached the scan, failed with
+    `unknown command "git"`, and the non-zero exit was reported as
+    "secrets detected in repository!".
+    """
+
+    @staticmethod
+    def _too_old(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+        """Installed, but the `git` probe fails. Returns the messages emitted."""
+        _fake_gitleaks(monkeypatch)
+        monkeypatch.setattr(gitleaks, "_supports_git_subcommand", lambda: False)
+        messages: list[str] = []
+        monkeypatch.setattr(gitleaks, "error", messages.append)
+        monkeypatch.setattr(gitleaks, "warn", messages.append)
+        return messages
+
+    def test_never_reported_as_a_finding(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The whole point: do not send anyone hunting a secret that is not there."""
+        messages = self._too_old(monkeypatch)
+        gitleaks.run(_cfg({"quality": {"gitleaks": "blocking"}}))
+
+        assert not any("secrets detected" in m for m in messages), messages
+        assert any("no scan ran" in m for m in messages), messages
+
+    def test_blocking_mode_still_fails(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Exit code is unchanged from the old behaviour - only the reason moved."""
+        self._too_old(monkeypatch)
+        assert gitleaks.run(_cfg({"quality": {"gitleaks": "blocking"}})) == 1
+
+    def test_warn_mode_still_passes(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._too_old(monkeypatch)
+        assert gitleaks.run(_cfg({"quality": {"gitleaks": "warn"}})) == 0
+
+    def test_no_scan_is_attempted(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Bailing before the scan is what keeps the exit code meaningful."""
+        calls = _fake_gitleaks(monkeypatch)
+        monkeypatch.setattr(gitleaks, "_supports_git_subcommand", lambda: False)
+        gitleaks.run(_cfg({"quality": {"gitleaks": "blocking"}}))
+
+        assert not [c for c in calls if c and c[0] == "gitleaks"], calls
+
+
+class TestGitSubcommandProbe:
+    """The probe itself, against the two exit codes real builds produce."""
+
+    @pytest.mark.parametrize(
+        ("returncode", "supported"),
+        [(0, True), (1, False)],
+        ids=["8.30.1-prints-help", "8.16.0-unknown-command"],
+    )
+    def test_probe_follows_the_exit_code(
+        self, monkeypatch: pytest.MonkeyPatch, returncode: int, supported: bool
+    ) -> None:
+        def fake_run_cmd(
+            cmd: list[str], **kwargs: object
+        ) -> subprocess.CompletedProcess:
+            assert cmd == ["gitleaks", "git", "--help"]
+            return subprocess.CompletedProcess(cmd, returncode, "", "")
+
+        monkeypatch.setattr(gitleaks, "run_cmd", fake_run_cmd)
+        assert gitleaks._supports_git_subcommand() is supported
+
+    def test_missing_binary_is_not_supported(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """run_cmd does not catch OSError, and a probe must not raise out of run()."""
+
+        def boom(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess:
+            raise FileNotFoundError(cmd[0])
+
+        monkeypatch.setattr(gitleaks, "run_cmd", boom)
+        assert gitleaks._supports_git_subcommand() is False
 
 
 class TestDetachedHead:

--- a/tests/unit/test_tools.py
+++ b/tests/unit/test_tools.py
@@ -35,6 +35,23 @@ def test_notice_for_unknown_tool_is_generic_but_safe() -> None:
     assert "docs:" not in notice
 
 
+def test_head_override_replaces_the_not_installed_opening() -> None:
+    """A present-but-unusable tool must not be described as missing.
+
+    gitleaks 8.16.0 is installed and on PATH; it simply cannot run the scan.
+    Saying "is not installed" there sends the reader to fix the wrong thing.
+    """
+    notice = tools.missing_tool_notice(
+        "gitleaks", head="`gitleaks` is installed but too old"
+    )
+    assert "is not installed" not in notice
+    assert notice.startswith("`gitleaks` is installed but too old")
+    # The whole reason for the parameter: keep the registry's install guidance
+    # rather than restating it locally to avoid the false opening.
+    assert "help: install it with one of:" in notice
+    assert "hyperi-ci needs it for secret scanning" in notice
+
+
 def test_notice_overrides_win() -> None:
     notice = tools.missing_tool_notice(
         "alint",


### PR DESCRIPTION
## The bug

`_install_gitleaks` is satisfied by anything named `gitleaks` on PATH, and every
non-zero exit from the scan was reported as a finding. gitleaks exits non-zero
for a **usage error** as well as for a leak, so a build that could not run the
scan at all was indistinguishable from a repo with a secret in it:

```
Error: unknown command "git" for "gitleaks"
ERROR   gitleaks: secrets detected in repository!
ERROR   Review output above and remove/rotate exposed secrets.
```

Ubuntu universe ships **8.16.0**, which predates the **8.19.0** split of
`detect` into `git`/`dir`/`stdin`
([#1504](https://github.com/gitleaks/gitleaks/releases/tag/v8.19.0)). Any host
with that package hits this on every run.

Costly in both directions: it sends someone hunting a secret that was never
there, and once *"gitleaks is broken again"* becomes the expected output, the
next **real** finding gets forced past with `--force`. That is not
hypothetical — it is how it was found, and it blocked `hyperi-ci check` and
`hyperi-ci push` outright for a whole session.

CI never showed it, because `_install_gitleaks` fetches the pinned build there.
This only ever bites local runs.

## The change

The build is probed before the scan is attempted. **Probed**, not parsed from
`gitleaks version` — a distro build prints `version is set by build process`,
with no number to compare.

## Exit codes are unchanged

`_report_unusable` returns exactly what the scan-failure path returned for the
same mode — `1` when blocking, `0` when warn. **No project's gate flips.** Only
the reason it gives moves.

Whether an unusable build should instead warn-skip the way a *missing* one
already does is a real question, and deliberately **not** decided here — that
would change behaviour for every repo, so it is yours to call.

`missing_tool_notice` gains a keyword-only `head` override so the notice can say
"installed but too old" rather than "is not installed", which is false when the
binary is present. Additive; every existing caller renders identically, and
`tools.py` stays the SSoT for install guidance rather than gitleaks.py
restating it.

## Verification

Against **both real binaries**, not mocks alone:

| build | probe | `run()` | reported |
|---|---|---|---|
| 8.16.0 (apt) | `False` | `1` | tool problem, no scan attempted |
| 8.30.1 (upstream) | `True` | `0` | scanned 52 commits, clean |

- 51 tests pass in `test_gitleaks.py` + `test_tools.py` (8 new).
- The four new `run()` tests were confirmed **non-vacuous** by disabling the
  guard: three fail without it, with the right diagnostics.
- Full suite: **2127 passed**. The 10 failures in `test_container_detect.py` /
  `test_container_stage.py` are pre-existing and environmental — `cargo` is not
  installed on this host — confirmed by stashing this change and reproducing
  the identical 10 on a clean tree.

## Unrelated observation

Those 10 cargo failures are the same shape as the bug fixed here: a missing tool
surfacing as a hard test failure rather than a skip. Worth a separate look —
`_cargo_metadata` raises `FileNotFoundError` rather than guarding on
`shutil.which("cargo")`.
