### PR TITLE
fix(release): stamp VERSION in the job that commits it

### DIFF
--- a/.github/workflows/_release-tail.yml
+++ b/.github/workflows/_release-tail.yml
@@ -408,8 +408,31 @@ jobs:
           R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
         run: ${{ env.HYPERCI_INSTALL }} run publish
 
+      - name: Stamp the released version
+        # release-commit reads VERSION off this job's disk, and this job checks
+        # out the TAG, whose VERSION is by definition the pre-release value.
+        # The build's stamp runs on a different runner and only dist/ + ci-tmp/
+        # travel between them, so without this VERSION never moves.
+        #
+        # Non-fatal, like the commit below: a failure leaves VERSION where it
+        # already was rather than reddening a shipped release.
+        if: steps.publish.outcome == 'success'
+        continue-on-error: true
+        env:
+          # Via env, not interpolated into the script, so the value cannot be
+          # read as shell.
+          RELEASE_VERSION: ${{ steps.forcedtag.outputs.version || inputs.next-version }}
+        run: |
+          # Guarded like the build's own stamp: a repo with no VERSION file has
+          # opted out, and creating one here would commit a file it never had.
+          if [[ -f VERSION ]]; then
+            ${{ env.HYPERCI_INSTALL }} stamp-version "$RELEASE_VERSION"
+          else
+            echo "No VERSION file - nothing to stamp"
+          fi
+
       - name: Commit rendered release artefacts
-        # VERSION (stamped by the build) and CHANGELOG.md (rendered by
+        # VERSION (stamped just above) and CHANGELOG.md (rendered by
         # @semantic-release/changelog) have had no owner since
         # @semantic-release/git was dropped (issue #85).
         #

--- a/tests/unit/test_workflow_consistency.py
+++ b/tests/unit/test_workflow_consistency.py
@@ -190,6 +190,50 @@ class TestFromHeadThreading:
             "forced-tag step must skip when bump == 'auto' (auto uses semantic-release)"
         )
 
+    def test_release_tail_restamps_before_committing_artefacts(self) -> None:
+        """VERSION must be stamped in the job that commits it.
+
+        release-commit lists VERSION in RELEASE_ARTEFACTS and reads it off
+        disk, but tag-and-publish checks out the TAG, whose VERSION is the
+        pre-release value. The build's stamp runs on another runner and only
+        dist/ + ci-tmp/ are passed between them, so without a stamp here the
+        uploaded blob matches the branch, the tree is unchanged for that path,
+        and VERSION never moves in any repo on this pipeline.
+        """
+        steps = _load_workflow("_release-tail.yml")["jobs"]["tag-and-publish"]["steps"]
+        names = [s.get("name") for s in steps]
+
+        assert "Stamp the released version" in names, (
+            "_release-tail.tag-and-publish: no stamp step before release-commit, "
+            "so VERSION can never move"
+        )
+        stamp_at = names.index("Stamp the released version")
+        commit_at = names.index("Commit rendered release artefacts")
+        assert stamp_at < commit_at, (
+            "the stamp must precede release-commit, which reads VERSION off disk"
+        )
+
+        stamp = steps[stamp_at]
+        commit = steps[commit_at]
+        # Same gate as the commit it feeds: stamping a release that did not
+        # publish would leave a version on disk nothing shipped.
+        assert str(stamp["if"]) == str(commit["if"]), (
+            "stamp and release-commit must share a condition"
+        )
+        assert stamp["continue-on-error"] is True, (
+            "bookkeeping after a shipped release must not turn it red"
+        )
+        # The version arrives by env so it is never read as shell.
+        assert "RELEASE_VERSION" in stamp["env"]
+        assert stamp["env"]["RELEASE_VERSION"] == commit["run"].split('"')[1], (
+            "stamp and release-commit must stamp and commit the SAME version"
+        )
+        # A repo with no VERSION file has opted out; stamp_version would create
+        # one, and release-commit would then commit a file it never had.
+        assert "-f VERSION" in stamp["run"], (
+            "stamp step must not create a VERSION file where none exists"
+        )
+
     @pytest.mark.parametrize("workflow_name", LANGUAGE_WORKFLOWS)
     def test_build_stamps_on_from_head_dispatch(self, workflow_name: str) -> None:
         # The from-head build-stamp gap (issue #37 / #27): HEAD's committed tree


### PR DESCRIPTION
## The bug

`release-commit` lists `VERSION` in `RELEASE_ARTEFACTS` and reads it off disk —
but `tag-and-publish` checks out the **tag**, whose `VERSION` is by definition
the pre-release value. The build's stamp runs on a **different runner**, and
only `dist/` + `ci-tmp/` travel between them.

So release-commit uploaded a blob identical to the branch, the tree was
unchanged for that path, and **VERSION never moved**. Only `CHANGELOG.md` ever
did.

| # | Fact | Where |
|---|---|---|
| 1 | `RELEASE_ARTEFACTS = ("VERSION", "CHANGELOG.md")` | `release_commit.py:40` |
| 2 | "VERSION (stamped by the build)" | `_release-tail.yml` comment |
| 3 | tag-and-publish checks out the tag, `persist-credentials: false` | `_release-tail.yml` |
| 4 | VERSION stamped in the **build** job | `python-ci.yml:358-361` |
| 5 | artefact = `dist/` + `ci-tmp/`, no VERSION — same in **all four** shared workflows | `{rust,python,ts,go}-ci.yml` |

Observed downstream in culvert: `VERSION` stuck at 2.1.10 across v2.1.11/12/13,
with every release commit touching `CHANGELOG.md` alone.

## Why this was invisible

**hyperi-ci itself is not affected**, which masked it. Its bespoke
`.github/workflows/ci.yml` puts `VERSION` in the build artefact — added to "pin
the artifact root", not to fix any of this — so the stamped file happens to
reach tag-and-publish and gets committed. `git log -- VERSION` here shows a
`chore(release)` commit per version.

The one repo where the contract works is the one it was never written for.

## Why stamp here rather than add VERSION to four artefact lists

- single point instead of four;
- independent of what any build chooses to upload;
- also covers a `tag` dispatch, which need not have a build artefact at all;
- `hyperi-ci stamp-version` already existed for exactly this and **had no
  caller** — `rg 'stamp-version' .github` finds only comments, and
  python-ci/rust-ci each stamp with their own inline bash before build.

## Safety

- **Guarded** on the VERSION file existing, matching the build's own
  `if [[ -f VERSION ]]`. `stamp_version()` writes unconditionally, so without
  the guard a repo with no VERSION file would have one created *and then
  committed*.
- **Non-fatal**, and gated on `publish.outcome == 'success'` — the same
  condition as the commit it feeds. A failure leaves VERSION where it already
  was rather than reddening a shipped release.
- Version passed via `env`, never interpolated into the shell.
- **Idempotent for hyperi-ci**: the stamp runs *after* the artefact download and
  rewrites the same value the artefact carried.

## Downstream consequence, stated deliberately

Repos deriving files from VERSION will now see them go **stale after a release**
rather than silently staying correct-looking. culvert generates its Helm chart
`appVersion` from VERSION and has a test for exactly that drift, so its `main`
will go red after a release until the chart is regenerated.

That is the intended signal — a chart pointing at an image that does not exist
yet should not be shippable — and regenerating in the same commit is the
follow-up (a declared `release.regenerate:` hook). This change is what makes the
drift visible at all.

## Verification

- 121 pass in `test_workflow_consistency.py` (1 new), full suite **2128 passed**.
- The new test was confirmed **non-vacuous** by renaming the step — it fails
  with "no stamp step before release-commit, so VERSION can never move".
- Step placement, condition, `continue-on-error`, env and guard all asserted
  against the parsed YAML, not a text match.
- Pre-existing: 10 `cargo` failures in `test_container_detect.py` /
  `test_container_stage.py` — `cargo` is absent on the authoring host; identical
  10 reproduce on a clean tree.

This workflow is self-hosted (`ci.yml` uses `./.github/workflows/_release-tail.yml`),
so hyperi-ci's own next release exercises the change.
